### PR TITLE
fix: unify default URL path between client and server

### DIFF
--- a/cmd/sshoq-server.go
+++ b/cmd/sshoq-server.go
@@ -1055,7 +1055,7 @@ func ServerMain() int {
 	bindAddr := flag.String("bind", "[::]:443", "the address:port pair to listen to, e.g. 0.0.0.0:443")
 	verbose := flag.Bool("v", false, "verbose mode, if set")
 	displayVersion := flag.Bool("version", false, "if set, displays the software version on standard output and exit")
-	urlPath := flag.String("url-path", "/ssh3-term", "the secret URL path on which the ssh3 server listens")
+	urlPath := flag.String("url-path", ssh3.DEFAULT_URL_PATH, "the secret URL path on which the ssh3 server listens")
 	generateSelfSignedCert := flag.Bool("generate-selfsigned-cert", false, "if set, generates a self-self-signed cerificate and key "+
 		"that will be stored at the paths indicated by the -cert and -key args (they must not already exist)")
 	certPath := flag.String("cert", "./cert.pem", "the filename of the server certificate (or fullchain)")
@@ -1132,7 +1132,7 @@ func ServerMain() int {
 			certPathExists = true
 			keyPathExists = true
 		}
-		
+
 	}
 
 	if *verbose {

--- a/cmd/sshoq.go
+++ b/cmd/sshoq.go
@@ -286,8 +286,11 @@ func getConfigOptions(hostUrl *url.URL, sshConfig *ssh_config.Config, optionPars
 	}
 
 	urlPath := hostUrl.Path
-	if urlPath == "" {
+	if urlPath == "" || urlPath == "/" {
 		urlPath = configUrlPath
+	}
+	if urlPath == "" || urlPath == "/" {
+		urlPath = ssh3.DEFAULT_URL_PATH
 	}
 	return client_config.NewConfig(username, hostname, port, urlPath, configAuthMethods, pluginOptions)
 }

--- a/conversation.go
+++ b/conversation.go
@@ -120,6 +120,10 @@ func (c *Conversation) EstablishClientConversation(req *http.Request, roundTripp
 			return rsp, Version{}, err
 		}
 
+		if rsp.StatusCode == http.StatusNotFound {
+			return rsp, Version{}, util.OtherHTTPError{StatusCode: 404}
+		}
+
 		log.Debug().Msgf("got response with %s status code", rsp.Status)
 
 		serverVersionStr := rsp.Header.Get("Server")

--- a/version.go
+++ b/version.go
@@ -26,6 +26,7 @@ const SOFTWARE_IMPLEMENTATION_NAME string = "h4sh5/sshoq"
 const SOFTWARE_MAJOR int = 0
 const SOFTWARE_MINOR int = 1
 const SOFTWARE_PATCH int = 10
+const DEFAULT_URL_PATH string = "/ssh3-term"
 
 const SOFTWARE_RC int = 0
 


### PR DESCRIPTION
## Summary

Fixes connectivity issues where the client defaulted to `/` while the server defaulted to `/ssh3-term`, causing 404 errors.

## Changes

- Add `DEFAULT_URL_PATH` constant in `version.go` for consistency
- Update server to use the constant for `-url-path` flag default
- Update client to fall back to `DEFAULT_URL_PATH` when path is empty or `/`
- Handle 404 responses early in `conversation.go` to provide clearer error messages instead of failing on version string parsing