### PR TITLE
sftp client: add wildcard/glob support to ls

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,11 @@ jobs:
         run: sudo -E PATH=$PATH SSH3_INTEGRATION_TESTS_KEY_DIR=/ ${{ github.workspace }}/setup_integration_tests.sh
       - name: Install
         run: make install
+      - name: Classical unit tests
+        run: make -e test
+        env:
+          GOOS: ${{matrix.goos}}
+          GOARCH: ${{matrix.goarch}}
       - name: Integration tests
         run: sudo -E PATH=$PATH make -e integration-tests
         env:

--- a/sftp/client.go
+++ b/sftp/client.go
@@ -114,25 +114,9 @@ func RunInteractiveClient(c *client.Client) error {
 			}
 
 		case "ls":
-			target := remoteDir
-			if len(parts) > 1 {
-				if path.IsAbs(parts[1]) {
-					target = parts[1]
-				} else {
-					target = path.Join(remoteDir, parts[1])
-				}
-			}
-			resp, err := doRequest(channel, &Request{Cmd: "ls", Path: target})
-			if err != nil {
+			if err := doLs(channel, remoteDir, parts); err != nil {
 				fmt.Fprintf(os.Stderr, "ls: %s\n", err)
 				continue
-			}
-			if !resp.OK {
-				fmt.Fprintf(os.Stderr, "ls: %s\n", resp.Error)
-				continue
-			}
-			for _, e := range resp.Entries {
-				printEntry(e.Name, sftpFileInfoFromEntry(e))
 			}
 
 		case "get":
@@ -249,6 +233,94 @@ func RunInteractiveClient(c *client.Client) error {
 	}
 
 	return scanner.Err()
+}
+
+func doLs(channel ssh3.Channel, remoteDir string, parts []string) error {
+	arg := ""
+	if len(parts) > 1 {
+		arg = parts[1]
+	}
+
+	// Split a possibly-globbed argument into the directory to list and a
+	// pattern to filter its entries. Glob metacharacters (*, ?, [range]) only
+	// apply to the final path component, matching shell glob semantics; "*" does
+	// not cross a "/". When arg has no metacharacters we fall back to listing
+	// the path directly, preserving the previous behavior.
+	listDir := arg
+	pattern := ""
+	if dir, pat, ok := globSplit(arg); ok {
+		listDir = dir
+		pattern = pat
+	}
+
+	// Resolve the directory relative to the remote working directory, mirroring
+	// the handling of a non-glob "ls <path>".
+	if pattern != "" || listDir != "" {
+		if listDir == "" {
+			listDir = remoteDir
+		} else if !path.IsAbs(listDir) {
+			listDir = path.Join(remoteDir, listDir)
+		}
+	} else {
+		listDir = remoteDir
+	}
+
+	resp, err := doRequest(channel, &Request{Cmd: "ls", Path: listDir})
+	if err != nil {
+		return err
+	}
+	if !resp.OK {
+		return fmt.Errorf("%s", resp.Error)
+	}
+
+	entries := resp.Entries
+	if pattern != "" {
+		var matched []FileInfo
+		for _, e := range entries {
+			ok, err := path.Match(pattern, e.Name)
+			if err != nil {
+				return fmt.Errorf("invalid pattern \"%s\": %w", pattern, err)
+			}
+			if ok {
+				matched = append(matched, e)
+			}
+		}
+		entries = matched
+	}
+
+	for _, e := range entries {
+		printEntry(e.Name, sftpFileInfoFromEntry(e))
+	}
+	return nil
+}
+
+// globSplit reports whether arg contains glob metacharacters in its final path
+// component and, if so, returns the directory prefix (before the last "/") and
+// the pattern (the final component) to match against directory entries. When arg
+// has no metacharacters it returns ("", "", false).
+func globSplit(arg string) (dir, pattern string, ok bool) {
+	// The final path component starts after the last "/".
+	slash := -1
+	for i := 0; i < len(arg); i++ {
+		if arg[i] == '/' {
+			slash = i
+		}
+	}
+	component := arg
+	if slash >= 0 {
+		component = arg[slash+1:]
+	}
+
+	for i := 0; i < len(component); i++ {
+		switch component[i] {
+		case '*', '?', '[':
+			if slash < 0 {
+				return "", arg, true
+			}
+			return arg[:slash], arg[slash+1:], true
+		}
+	}
+	return "", "", false
 }
 
 func parseTransferArgs(parts []string, cmd string) (recursive bool, source string, target string, err error) {
@@ -417,7 +489,7 @@ func ensureRemoteDir(channel ssh3.Channel, remotePath string) error {
 func printHelp() {
 	fmt.Println(`Commands:
   cd <path>       change remote directory
-  ls [path]       list remote directory
+  ls [path]       list remote directory (path may contain * ? [glob] patterns)
   pwd             print remote working directory
   get [-r] <src> [dst]   download remote file or directory
   put [-r] <src> [dst]   upload local file or directory

--- a/sftp/sftp_test.go
+++ b/sftp/sftp_test.go
@@ -1161,3 +1161,154 @@ func TestBuildGroupIDs(t *testing.T) {
 		t.Fatalf("expected primary gid %d in %v", u.Gid, gids)
 	}
 }
+
+// captureStdout runs fn while routing standard output to a buffer, returning
+// whatever fn printed to stdout.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	os.Stdout = w
+
+	done := make(chan string)
+	go func() {
+		out, _ := io.ReadAll(r)
+		done <- string(out)
+	}()
+
+	fn()
+
+	if err := w.Close(); err != nil {
+		t.Fatalf("close write end: %v", err)
+	}
+	os.Stdout = old
+
+	// w is closed, so the goroutine's ReadAll unblocks and sends the captured
+	// buffer; a plain receive cannot deadlock.
+	return <-done
+}
+
+func TestGlobSplit(t *testing.T) {
+	cases := []struct {
+		arg         string
+		wantDir     string
+		wantPattern string
+		wantOK      bool
+	}{
+		{"", "", "", false},
+		{"plain", "", "", false},
+		{"path/plain", "", "", false},
+		{"a/b.c", "", "", false},
+		{"test*", "", "test*", true},
+		{"path/test*", "path", "test*", true},
+		{"*.txt", "", "*.txt", true},
+		{"[abc]", "", "[abc]", true},
+		{"f?o", "", "f?o", true},
+		{"dir/b*c", "dir", "b*c", true},
+		{"/home/test*", "/home", "test*", true},
+	}
+	for _, c := range cases {
+		dir, pat, ok := globSplit(c.arg)
+		if dir != c.wantDir || pat != c.wantPattern || ok != c.wantOK {
+			t.Errorf("globSplit(%q) = (%q, %q, %v), want (%q, %q, %v)",
+				c.arg, dir, pat, ok, c.wantDir, c.wantPattern, c.wantOK)
+		}
+	}
+}
+
+func lsEntries(names ...string) []FileInfo {
+	out := make([]FileInfo, 0, len(names))
+	for _, n := range names {
+		out = append(out, FileInfo{Name: n})
+	}
+	return out
+}
+
+func TestClientDoLsNoArg(t *testing.T) {
+	ch := newMockChannel(makeJSONDataMsg(&Response{
+		OK:      true,
+		Entries: lsEntries("."),
+	}))
+	if err := doLs(ch, "/remote", []string{"ls"}); err != nil {
+		t.Fatalf("doLs error: %v", err)
+	}
+	var got Request
+	if len(ch.Writes) != 1 {
+		t.Fatalf("expected 1 request, got %d", len(ch.Writes))
+	}
+	if err := json.Unmarshal(ch.Writes[0], &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.Cmd != "ls" || got.Path != "/remote" {
+		t.Fatalf("expected ls /remote, got %s %q", got.Cmd, got.Path)
+	}
+}
+
+func TestClientDoLsWildcard(t *testing.T) {
+	ch := newMockChannel(makeJSONDataMsg(&Response{
+		OK:      true,
+		Entries: lsEntries("atest", "test", "testa", "test2", "nope"),
+	}))
+	out := captureStdout(t, func() {
+		if err := doLs(ch, "/remote/path", []string{"ls", "test*"}); err != nil {
+			t.Fatalf("doLs error: %v", err)
+		}
+	})
+
+	var got Request
+	if len(ch.Writes) != 1 {
+		t.Fatalf("expected 1 request, got %d", len(ch.Writes))
+	}
+	if err := json.Unmarshal(ch.Writes[0], &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.Cmd != "ls" || got.Path != "/remote/path" {
+		t.Fatalf("expected ls /remote/path, got %s %q", got.Cmd, got.Path)
+	}
+	// Only entries whose final component matches test* must be printed.
+	for _, want := range []string{"test", "testa", "test2"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected %q in output:\n%s", want, out)
+		}
+	}
+	// Entries that do not match must not be listed. Neither "atest" nor "nope"
+	// is a substring of any matching name, so we can assert their absence.
+	if strings.Contains(out, "atest") || strings.Contains(out, "nope") {
+		t.Errorf("unexpected non-matching entry in output:\n%s", out)
+	}
+	lines := 0
+	for _, l := range strings.Split(out, "\n") {
+		if strings.TrimSpace(l) != "" {
+			lines++
+		}
+	}
+	if lines != 3 {
+		t.Errorf("expected 3 matching entries, got %d:\n%s", lines, out)
+	}
+}
+
+func TestClientDoLsNoMatch(t *testing.T) {
+	ch := newMockChannel(makeJSONDataMsg(&Response{
+		OK:      true,
+		Entries: lsEntries("one", "two"),
+	}))
+	out := captureStdout(t, func() {
+		if err := doLs(ch, "/remote", []string{"ls", "zzz*"}); err != nil {
+			t.Fatalf("doLs error: %v", err)
+		}
+	})
+	if strings.TrimSpace(out) != "" {
+		t.Errorf("expected no output for non-matching glob, got:\n%s", out)
+	}
+}
+
+func TestClientDoLsInvalidPattern(t *testing.T) {
+	ch := newMockChannel(makeJSONDataMsg(&Response{OK: true, Entries: lsEntries("a")}))
+	err := doLs(ch, "/remote", []string{"ls", "["})
+	if err == nil {
+		t.Fatal("expected error for invalid glob pattern")
+	}
+}


### PR DESCRIPTION
The ls command now accepts shell-style glob patterns (`*, ?, [range]`) in its path argument. When the final path component contains a metacharacter, the client lists the parent directory and filters the returned entries with path.Match, so e.g. 'ls path/test*' lists every entry under path/ that begins with 'test'. Non-glob arguments keep their previous directory-listing behavior.