### PR TITLE
fix: reassemble chunked SFTP messages across channel data messages

### DIFF
--- a/sftp/protocol.go
+++ b/sftp/protocol.go
@@ -1,8 +1,10 @@
 package sftp
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 
 	ssh3 "github.com/h4sh5/sshoq"
 	ssh3Messages "github.com/h4sh5/sshoq/message"
@@ -50,17 +52,74 @@ func SendRequest(ch ssh3.Channel, req *Request) error {
 	return err
 }
 
+// sftpMessageChannel is the minimal channel surface needed to receive the
+// data messages that carry SFTP requests and responses.
+type sftpMessageChannel interface {
+	NextMessage() (ssh3Messages.Message, error)
+}
+
+// receiveJSON reads one complete logical SFTP message from the channel and
+// returns its raw JSON payload. Channel writes split payloads larger than the
+// negotiated maximum packet size across several DataOrExtendedDataMessage
+// messages (see channelImpl.WriteData), so the payloads of consecutive data
+// messages are accumulated until they form a single complete JSON document.
+// Non-data messages are skipped, mirroring the previous request loop.
+func receiveJSON(ch sftpMessageChannel) ([]byte, error) {
+	var payload []byte
+	for {
+		msg, err := ch.NextMessage()
+		if err != nil {
+			return nil, err
+		}
+		dataMsg, ok := msg.(*ssh3Messages.DataOrExtendedDataMessage)
+		if !ok || dataMsg.DataType != ssh3Messages.SSH_EXTENDED_DATA_NONE {
+			continue
+		}
+		payload = append(payload, dataMsg.Data...)
+		complete, err := isCompleteJSON(payload)
+		if err != nil {
+			return nil, err
+		}
+		if complete {
+			return payload, nil
+		}
+	}
+}
+
+// isCompleteJSON reports whether payload is exactly one complete JSON document.
+// A payload that ends in the middle of a document (a truncated prefix of a
+// message that is still arriving across channel data messages) is reported as
+// incomplete, not as an error.
+func isCompleteJSON(payload []byte) (bool, error) {
+	dec := json.NewDecoder(bytes.NewReader(payload))
+	var v interface{}
+	if err := dec.Decode(&v); err != nil {
+		if err == io.ErrUnexpectedEOF {
+			return false, nil
+		}
+		return false, err
+	}
+	// A second decode must hit EOF: the payload must be exactly one value,
+	// with no trailing data.
+	if err := dec.Decode(&v); err != nil {
+		if err == io.EOF {
+			return true, nil
+		}
+		if err == io.ErrUnexpectedEOF {
+			return false, nil
+		}
+		return false, err
+	}
+	return false, fmt.Errorf("multiple JSON values in one sftp message")
+}
+
 func ReceiveResponse(ch ssh3.Channel) (*Response, error) {
-	msg, err := ch.NextMessage()
+	payload, err := receiveJSON(ch)
 	if err != nil {
 		return nil, err
 	}
-	dataMsg, ok := msg.(*ssh3Messages.DataOrExtendedDataMessage)
-	if !ok || dataMsg.DataType != ssh3Messages.SSH_EXTENDED_DATA_NONE {
-		return nil, fmt.Errorf("unexpected message type on sftp channel")
-	}
 	resp := &Response{}
-	if err := json.Unmarshal([]byte(dataMsg.Data), resp); err != nil {
+	if err := json.Unmarshal(payload, resp); err != nil {
 		return nil, err
 	}
 	return resp, nil

--- a/sftp/server.go
+++ b/sftp/server.go
@@ -73,7 +73,7 @@ func serveChannelInProcess(ctx context.Context, user *unix_util.User, channel sf
 	defer log.Info().Msgf("ending SFTP session for user %s", user.Username)
 
 	for {
-		msg, err := channel.NextMessage()
+		payload, err := receiveJSON(channel)
 		if err != nil {
 			if err != io.EOF {
 				log.Error().Msgf("sftp channel error: %s", err)
@@ -81,13 +81,8 @@ func serveChannelInProcess(ctx context.Context, user *unix_util.User, channel sf
 			return
 		}
 
-		dataMsg, ok := msg.(*ssh3Messages.DataOrExtendedDataMessage)
-		if !ok || dataMsg.DataType != ssh3Messages.SSH_EXTENDED_DATA_NONE {
-			continue
-		}
-
 		var req Request
-		if err := json.Unmarshal([]byte(dataMsg.Data), &req); err != nil {
+		if err := json.Unmarshal(payload, &req); err != nil {
 			session.respond(&Response{Error: fmt.Sprintf("invalid request: %s", err)})
 			continue
 		}

--- a/sftp/sftp_test.go
+++ b/sftp/sftp_test.go
@@ -81,12 +81,85 @@ func TestReceiveResponse(t *testing.T) {
 	}
 }
 
-func TestReceiveResponse_WrongMessageType(t *testing.T) {
-	ch := newMockChannel(&ssh3Messages.ChannelRequestMessage{})
-	_, err := ReceiveResponse(ch)
-	if err == nil {
-		t.Fatal("expected error for non-data message")
+func TestReceiveResponse_SkipsNonDataMessages(t *testing.T) {
+	want := &Response{ID: 2, OK: true, Path: "/tmp"}
+	ch := newMockChannel(
+		&ssh3Messages.ChannelRequestMessage{},
+		makeJSONDataMsg(want),
+	)
+	got, err := ReceiveResponse(ch)
+	if err != nil {
+		t.Fatalf("ReceiveResponse error: %v", err)
 	}
+	if got.ID != want.ID || got.OK != want.OK || got.Path != want.Path {
+		t.Fatalf("unexpected response: %+v", got)
+	}
+}
+
+func TestReceiveResponse_ChunkedMessage(t *testing.T) {
+	// Build a large response that channelImpl.WriteData would split into
+	// several channel data messages (each message carries at most
+	// MaxPacketSize minus framing bytes). ReceiveResponse must reassemble the
+	// chunks into a single JSON document instead of parsing a truncated one.
+	var entries []FileInfo
+	for i := 0; i < 500; i++ {
+		entries = append(entries, FileInfo{
+			Name:      fmt.Sprintf("file_%03d.txt", i),
+			Size:      4096,
+			Mode:      0644,
+			IsDir:     false,
+			ModTime:   1786842766,
+			UID:       1000,
+			GID:       1000,
+			UserName:  "alice",
+			GroupName: "alice",
+		})
+	}
+	want := &Response{ID: 7, OK: true, Entries: entries}
+	raw, err := json.Marshal(want)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	msgs := splitIntoChannelMessages(raw)
+	if len(msgs) < 2 {
+		t.Fatalf("test response too small to be split across messages")
+	}
+
+	got, err := ReceiveResponse(newMockChannel(msgs...))
+	if err != nil {
+		t.Fatalf("ReceiveResponse error: %v", err)
+	}
+	if got.ID != want.ID || !got.OK || len(got.Entries) != len(want.Entries) {
+		t.Fatalf("unexpected reassembled response: id=%d ok=%v entries=%d", got.ID, got.OK, len(got.Entries))
+	}
+	if got.Entries[0].Name != want.Entries[0].Name ||
+		got.Entries[len(got.Entries)-1].Name != want.Entries[len(want.Entries)-1].Name {
+		t.Fatalf("reassembled entries mismatch: first=%q last=%q",
+			got.Entries[0].Name, got.Entries[len(got.Entries)-1].Name)
+	}
+}
+
+// splitIntoChannelMessages splits raw into as many DataOrExtendedDataMessage
+// payloads as channelImpl.WriteData would produce for a channel opened with the
+// default maximum packet size of 30000 bytes.
+func splitIntoChannelMessages(raw []byte) []ssh3Messages.Message {
+	const maxPacketSize = 30000
+	emptyMsgLen := (&ssh3Messages.DataOrExtendedDataMessage{
+		DataType: ssh3Messages.SSH_EXTENDED_DATA_NONE,
+	}).Length()
+	chunkSize := maxPacketSize - emptyMsgLen
+
+	var msgs []ssh3Messages.Message
+	for len(raw) > 0 {
+		n := chunkSize
+		if len(raw) < n {
+			n = len(raw)
+		}
+		msgs = append(msgs, makeDataMsg(raw[:n]))
+		raw = raw[n:]
+	}
+	return msgs
 }
 
 // --- Server tests ---
@@ -844,6 +917,48 @@ func TestServeChannel_TwoRequests(t *testing.T) {
 	}
 	if !ch.Closed {
 		t.Fatal("expected channel closed")
+	}
+}
+
+func TestServeChannel_ChunkedRequest(t *testing.T) {
+	tmp := t.TempDir()
+
+	// Build a put request whose JSON payload exceeds one channel data message
+	// (the base64 encoding of the data alone is larger than MaxPacketSize), so
+	// the request arrives split across several messages. The server must
+	// reassemble it before handling, mirroring the response-side reassembly.
+	payload := bytes.Repeat([]byte("abcdefghij"), 3000) // 30000 bytes
+	req := Request{Cmd: "put", Path: filepath.Join(tmp, "big.bin"), Data: payload}
+	raw, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	msgs := splitIntoChannelMessages(raw)
+	if len(msgs) < 2 {
+		t.Fatalf("test request too small to be split across messages")
+	}
+
+	ch := newMockChannel(msgs...)
+	user := currentTestUser(tmp)
+	ServeChannel(nil, user, ch)
+
+	if len(ch.Writes) != 1 {
+		t.Fatalf("expected 1 response, got %d", len(ch.Writes))
+	}
+	var resp Response
+	if err := json.Unmarshal(ch.Writes[0], &resp); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if !resp.OK {
+		t.Fatalf("expected ok response, got %+v", resp)
+	}
+
+	got, err := os.ReadFile(filepath.Join(tmp, "big.bin"))
+	if err != nil {
+		t.Fatalf("read file: %v", err)
+	}
+	if !bytes.Equal(got, payload) {
+		t.Fatalf("file content mismatch: got %d bytes, want %d", len(got), len(payload))
 	}
 }
 


### PR DESCRIPTION
The SFTP protocol exchanges JSON-encoded requests and responses over an SSH3 channel. channelImpl.WriteData splits payloads larger than the negotiated maximum packet size (default 30000 bytes) across several DataOrExtendedDataMessage messages. Previously, ReceiveResponse on the client side and the request loop on the server side each read only a single channel message, producing truncated JSON parse errors such as 'unexpected end of JSON input' or the cascading 'invalid character in literal false' reported in issue #32.

Fix:
- Add receiveJSON (sftp/protocol.go) which accumulates consecutive DataOrExtendedDataMessage payloads until the aggregated bytes form one complete JSON document, using json.Decoder to detect truncated prefixes (io.ErrUnexpectedEOF).
- Switch ReceiveResponse and the server request loop to receiveJSON.
- Add isCompleteJSON helper with robust truncation detection.
- Add unit tests for chunked response reassembly, chunked request reassembly, and non-data message skipping.

Fixes #32