### PR TITLE
fix: print error to stderr when sshoq-server fails to start

### DIFF
--- a/cmd/sshoq-server.go
+++ b/cmd/sshoq-server.go
@@ -1361,6 +1361,11 @@ func ServerMain() int {
 	err = server.ListenAndServe()
 
 	if err != nil {
+		// print to stderr as well as the log file: the "Server started" message
+		// has already been displayed, and users should not have to inspect the
+		// log file to understand why the server failed to start (e.g. another
+		// server is already listening on the same address)
+		fmt.Fprintf(os.Stderr, "error while serving HTTP connection: %s\n", err)
 		log.Error().Msgf("error while serving HTTP connection: %s", err)
 		return -1
 	}


### PR DESCRIPTION
When another server is already listening on the same address, server.ListenAndServe() returns an error but it was only written to the log file (sshoq.log). Since the 'Server started' message is printed before ListenAndServe() is called, users saw the startup message followed by the shell prompt with no indication that the server failed to start.

Now the error is printed to stderr as well, so users clearly see e.g. 'bind: address already in use'.