### PR TITLE
Feature/default ssh keys from dot ssh

### DIFF
--- a/auth/plugins/pubkey_authentication/client/privkey_auth.go
+++ b/auth/plugins/pubkey_authentication/client/privkey_auth.go
@@ -119,6 +119,7 @@ func (m *PrivkeyFileAuthMethod) getCryptoMaterial() (crypto.Signer, jwt.SigningM
 // PrepareRequestForAuth implements auth.ClientAuthMethod.
 func (m *PrivkeyFileAuthMethod) PrepareRequestForAuth(request *http.Request, sshAgent agent.ExtendedAgent, roundTripper *http3.RoundTripper, username string, conversation *ssh3.Conversation) error {
 	log.Debug().Msgf("try file-based privkey auth using file %s", m.Filename())
+	fmt.Fprintf(os.Stderr, "Trying private key: %s\n", m.Filename())
 	var jwtBearerKey any
 	jwtBearerKey, signingMethod, err := m.getCryptoMaterial()
 	// could not identify without passphrase, try agent authentication by using the key's public key

--- a/client/client.go
+++ b/client/client.go
@@ -445,6 +445,7 @@ func Dial(ctx context.Context, config *client_config.Config, qconn quic.EarlyCon
 				identity = m.IntoIdentity(string(password))
 			case *ssh3.PrivkeyFileAuthMethod:
 				log.Debug().Msgf("try file-based pubkey auth using file %s", m.Filename())
+				fmt.Fprintf(os.Stderr, "Trying private key: %s\n", m.Filename())
 				identity, err = m.IntoIdentityWithoutPassphrase()
 				// could not identify without passphrase, try agent authentication by using the key's public key
 				if passphraseErr, ok := err.(*ssh.PassphraseMissingError); ok {

--- a/client/client.go
+++ b/client/client.go
@@ -409,8 +409,18 @@ func Dial(ctx context.Context, config *client_config.Config, qconn quic.EarlyCon
 	}
 	req.Proto = "ssh3"
 
-	// TODO: replace this by a loop actually performing the requests for qeach auth method of each plugin
-	foundSuitableAuthPlugin := false
+	// authAttempt represents a single authentication attempt against the
+	// server. The prepare function must set the necessary headers on the
+	// given request (e.g. Authorization) and return nil on success, or an
+	// error if the method cannot be prepared (e.g. missing key file).
+	type authAttempt struct {
+		prepare func(freshReq *http.Request) error
+		name    string
+	}
+
+	var attempts []authAttempt
+
+	// Collect plugin-based auth methods (used for -i, IdentityFile in config, etc.)
 	plugins := internal.GetClientAuthPlugins()
 	for _, plugin := range plugins {
 		authMethods, err := plugin.PluginFunc(req, sshAgent, config, roundTripper)
@@ -418,131 +428,155 @@ func Dial(ctx context.Context, config *client_config.Config, qconn quic.EarlyCon
 			return nil, err
 		}
 		for _, authMethod := range authMethods {
-			err = authMethod.PrepareRequestForAuth(req, sshAgent, roundTripper, config.Username(), conv)
-			if err != nil {
-				log.Error().Msgf("error when preparing request for auth plugin %T: %s", plugin, err)
-				return nil, err
-			}
-			foundSuitableAuthPlugin = true
-			log.Debug().Msgf("found suitable auth plugin")
+			authMethod := authMethod
+			attempts = append(attempts, authAttempt{
+				prepare: func(freshReq *http.Request) error {
+					return authMethod.PrepareRequestForAuth(freshReq, sshAgent, roundTripper, config.Username(), conv)
+				},
+				name: fmt.Sprintf("plugin/%T", authMethod),
+			})
 		}
 	}
 
-	if !foundSuitableAuthPlugin {
-
-		var identity ssh3.Identity
+	// Collect legacy identity-based auth methods (default ~/.ssh keys, password, OIDC, etc.)
+	if len(attempts) == 0 {
 		for _, method := range config.AuthMethods() {
 			switch m := method.(type) {
 			case *ssh3.PasswordAuthMethod:
-				log.Debug().Msgf("try password-based auth")
-				fmt.Printf("password for %s:", hostUrl.String())
-				password, err := term.ReadPassword(int(syscall.Stdin))
-				fmt.Println()
-				if err != nil {
-					log.Error().Msgf("could not get password: %s", err)
-					return nil, err
-				}
-				identity = m.IntoIdentity(string(password))
-			case *ssh3.PrivkeyFileAuthMethod:
-				log.Debug().Msgf("try file-based pubkey auth using file %s", m.Filename())
-				fmt.Fprintf(os.Stderr, "Trying private key: %s\n", m.Filename())
-				identity, err = m.IntoIdentityWithoutPassphrase()
-				// could not identify without passphrase, try agent authentication by using the key's public key
-				if passphraseErr, ok := err.(*ssh.PassphraseMissingError); ok {
-					// the pubkey may be contained in the privkey file
-					pubkey := passphraseErr.PublicKey
-					if pubkey == nil {
-						// if it is not the case, try to find a .pub equivalent, like OpenSSH does
-						pubkeyBytes, err := os.ReadFile(fmt.Sprintf("%s.pub", m.Filename()))
-						if err == nil {
-							filePubkey, _, _, _, err := ssh.ParseAuthorizedKey(pubkeyBytes)
-							if err == nil {
-								pubkey = filePubkey
-							}
-						}
-					}
-
-					// now, try to see of the agent manages this key
-					foundAgentKey := false
-					if pubkey != nil {
-						for _, agentKey := range agentKeys {
-							if bytes.Equal(agentKey.Marshal(), pubkey.Marshal()) {
-								log.Debug().Msgf("found key in agent: %s", agentKey)
-								identity = ssh3.NewAgentAuthMethod(pubkey).IntoIdentity(sshAgent)
-								foundAgentKey = true
-								break
-							}
-						}
-					}
-
-					// key not handled by agent, let's try to decrypt it ourselves
-					if !foundAgentKey {
-						fmt.Printf("passphrase for private key stored in %s:", m.Filename())
-						var passphraseBytes []byte
-						passphraseBytes, err = term.ReadPassword(int(syscall.Stdin))
+				attempts = append(attempts, authAttempt{
+					prepare: func(freshReq *http.Request) error {
+						log.Debug().Msgf("try password-based auth")
+						fmt.Printf("password for %s:", hostUrl.String())
+						password, err := term.ReadPassword(int(syscall.Stdin))
 						fmt.Println()
 						if err != nil {
-							log.Error().Msgf("could not get passphrase: %s", err)
-							return nil, err
+							return err
 						}
-						passphrase := string(passphraseBytes)
-						identity, err = m.IntoIdentityPassphrase(passphrase)
+						identity := m.IntoIdentity(string(password))
+						return identity.SetAuthorizationHeader(freshReq, config.Username(), conv)
+					},
+					name: "password",
+				})
+			case *ssh3.PrivkeyFileAuthMethod:
+				attempts = append(attempts, authAttempt{
+					prepare: func(freshReq *http.Request) error {
+						log.Debug().Msgf("try file-based pubkey auth using file %s", m.Filename())
+						fmt.Fprintf(os.Stderr, "Trying private key: %s\n", m.Filename())
+						identity, err := m.IntoIdentityWithoutPassphrase()
 						if err != nil {
-							log.Error().Msgf("could not load private key: %s", err)
-							return nil, err
+							// could not identify without passphrase, try agent authentication
+							if passphraseErr, ok := err.(*ssh.PassphraseMissingError); ok {
+								// the pubkey may be contained in the privkey file
+								pubkey := passphraseErr.PublicKey
+								if pubkey == nil {
+									// if not, try to find a .pub equivalent, like OpenSSH does
+									pubkeyBytes, readErr := os.ReadFile(fmt.Sprintf("%s.pub", m.Filename()))
+									if readErr == nil {
+										filePubkey, _, _, _, parseErr := ssh.ParseAuthorizedKey(pubkeyBytes)
+										if parseErr == nil {
+											pubkey = filePubkey
+										}
+									}
+								}
+
+								// now, try to see if the agent manages this key
+								foundAgentKey := false
+								if pubkey != nil {
+									for _, agentKey := range agentKeys {
+										if bytes.Equal(agentKey.Marshal(), pubkey.Marshal()) {
+											log.Debug().Msgf("found key in agent: %s", agentKey)
+											identity = ssh3.NewAgentAuthMethod(pubkey).IntoIdentity(sshAgent)
+											foundAgentKey = true
+											break
+										}
+									}
+								}
+
+								// key not handled by agent, let's try to decrypt it ourselves
+								if !foundAgentKey {
+									fmt.Printf("passphrase for private key stored in %s:", m.Filename())
+									passphraseBytes, readErr := term.ReadPassword(int(syscall.Stdin))
+									fmt.Println()
+									if readErr != nil {
+										return readErr
+									}
+									identity, err = m.IntoIdentityPassphrase(string(passphraseBytes))
+									if err != nil {
+										return err
+									}
+								}
+							} else {
+								// not a passphrase error, report the original error
+								return err
+							}
 						}
-					}
-				} else if err != nil {
-					log.Warn().Msgf("Could not load private key: %s", err)
-				}
+						if identity == nil {
+							return fmt.Errorf("could not load private key %s", m.Filename())
+						}
+						return identity.SetAuthorizationHeader(freshReq, config.Username(), conv)
+					},
+					name: fmt.Sprintf("privkey:%s", m.Filename()),
+				})
 			case *ssh3.AgentAuthMethod:
-				log.Debug().Msgf("try ssh-agent-based auth")
-				identity = m.IntoIdentity(sshAgent)
+				attempts = append(attempts, authAttempt{
+					prepare: func(freshReq *http.Request) error {
+						log.Debug().Msgf("try ssh-agent-based auth")
+						identity := m.IntoIdentity(sshAgent)
+						return identity.SetAuthorizationHeader(freshReq, config.Username(), conv)
+					},
+					name: "agent",
+				})
 			case *ssh3.OidcAuthMethod:
-				log.Debug().Msgf("try OIDC auth to issuer %s", m.OIDCConfig().IssuerUrl)
-				token, err := oidc.Connect(context.Background(), m.OIDCConfig(), m.OIDCConfig().IssuerUrl, m.DoPKCE())
-				if err != nil {
-					log.Error().Msgf("could not get token: %s", err)
-					return nil, err
-				}
-				identity = m.IntoIdentity(token)
+				attempts = append(attempts, authAttempt{
+					prepare: func(freshReq *http.Request) error {
+						log.Debug().Msgf("try OIDC auth to issuer %s", m.OIDCConfig().IssuerUrl)
+						token, err := oidc.Connect(context.Background(), m.OIDCConfig(), m.OIDCConfig().IssuerUrl, m.DoPKCE())
+						if err != nil {
+							return err
+						}
+						identity := m.IntoIdentity(token)
+						return identity.SetAuthorizationHeader(freshReq, config.Username(), conv)
+					},
+					name: "oidc",
+				})
 			}
-			// try several identities, similarly to OpenSSH: if the current method
-			// could not produce an identity (e.g. the private key file does not
-			// exist), try the next one instead of aborting
-			if identity != nil {
-				log.Debug().Msgf("found a suitable identity: %s", identity)
-				break
-			}
-			log.Debug().Msgf("auth method %T could not provide an identity, trying the next one", method)
-		}
-
-		if identity == nil {
-			return nil, NoSuitableIdentity{}
-		}
-
-		log.Debug().Msgf("try the following Identity: %s", identity)
-		err = identity.SetAuthorizationHeader(req, config.Username(), conv)
-		if err != nil {
-			log.Error().Msgf("could not set authorization header in HTTP request: %s", err)
-			return nil, err
 		}
 	}
 
-	log.Debug().Msgf("establish conversation with the server")
-	err = conv.EstablishClientConversation(req, roundTripper, ssh3.AVAILABLE_CLIENT_VERSIONS)
-	if errors.Is(err, util.Unauthorized{}) {
-		log.Error().Msgf("Access denied from the server: unauthorized")
-		return nil, err
-	} else if err != nil {
-		log.Error().Msgf("Could not establish conversation: %+v", err)
+	if len(attempts) == 0 {
+		return nil, NoSuitableIdentity{}
+	}
+
+	// Try each auth attempt in sequence, similarly to OpenSSH: if the server
+	// rejects one (unauthorized), try the next. Only fail if all attempts are
+	// exhausted or a non-auth error occurs.
+	var lastErr error
+	for _, attempt := range attempts {
+		// Fresh request for each attempt; headers must not leak between them
+		freshReq := req.Clone(context.Background())
+		if err := attempt.prepare(freshReq); err != nil {
+			log.Warn().Msgf("could not prepare auth method %s: %s", attempt.name, err)
+			lastErr = err
+			continue
+		}
+		log.Debug().Msgf("establish conversation with the server using %s", attempt.name)
+		err := conv.EstablishClientConversation(freshReq, roundTripper, ssh3.AVAILABLE_CLIENT_VERSIONS)
+		if err == nil {
+			log.Debug().Msgf("successfully authenticated with %s", attempt.name)
+			return &Client{
+				qconn:        qconn,
+				Conversation: conv,
+			}, nil
+		}
+		if errors.Is(err, util.Unauthorized{}) {
+			log.Warn().Msgf("server rejected auth method %s, trying the next one", attempt.name)
+			lastErr = err
+			continue
+		}
 		return nil, err
 	}
 
-	return &Client{
-		qconn:        qconn,
-		Conversation: conv,
-	}, nil
+	return nil, lastErr
 }
 
 //++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++

--- a/client/client.go
+++ b/client/client.go
@@ -506,10 +506,14 @@ func Dial(ctx context.Context, config *client_config.Config, qconn quic.EarlyCon
 				}
 				identity = m.IntoIdentity(token)
 			}
-			// currently only tries a single identity (the first one), but the goal is to
-			// try several identities, similarly to OpenSSH
-			log.Debug().Msgf("we only try the first specified auth method for now")
-			break
+			// try several identities, similarly to OpenSSH: if the current method
+			// could not produce an identity (e.g. the private key file does not
+			// exist), try the next one instead of aborting
+			if identity != nil {
+				log.Debug().Msgf("found a suitable identity: %s", identity)
+				break
+			}
+			log.Debug().Msgf("auth method %T could not provide an identity, trying the next one", method)
 		}
 
 		if identity == nil {

--- a/client_auth.go
+++ b/client_auth.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"path"
 	"strconv"
 	"time"
 
@@ -64,6 +65,45 @@ func NewPrivkeyFileAuthMethod(filename string) *PrivkeyFileAuthMethod {
 	return &PrivkeyFileAuthMethod{
 		filename: util.ExpandTildeWithHomeDir(filename),
 	}
+}
+
+// defaultPrivkeyBasenames lists the private key file names (relative to
+// ~/.ssh) that OpenSSH tries by default when no identity file is explicitly
+// configured, following the order of ssh_config(5).
+var defaultPrivkeyBasenames = []string{
+	"id_dsa",
+	"id_ecdsa",
+	"id_ecdsa_sk",
+	"id_ed25519",
+	"id_ed25519_sk",
+	"id_rsa",
+	"id_xmss",
+}
+
+// NewDefaultPrivkeyFileAuthMethods returns one PrivkeyFileAuthMethod per
+// default private key that exists in the user's ~/.ssh directory (e.g.
+// ~/.ssh/id_rsa, ~/.ssh/id_ed25519, ...).
+// Similarly to OpenSSH, only keys that actually exist on the filesystem are
+// returned, in the order they are tried by OpenSSH. If no default key is
+// found (or the home directory cannot be determined), an empty slice is
+// returned.
+func NewDefaultPrivkeyFileAuthMethods() []*PrivkeyFileAuthMethod {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		log.Warn().Msgf("could not determine home directory to look for default private keys: %s", err)
+		return nil
+	}
+	sshDir := path.Join(homeDir, ".ssh")
+	var methods []*PrivkeyFileAuthMethod
+	for _, basename := range defaultPrivkeyBasenames {
+		filename := path.Join(sshDir, basename)
+		info, err := os.Stat(filename)
+		if err != nil || info.IsDir() {
+			continue
+		}
+		methods = append(methods, NewPrivkeyFileAuthMethod(filename))
+	}
+	return methods
 }
 
 func (m *PrivkeyFileAuthMethod) Filename() string {

--- a/client_auth.go
+++ b/client_auth.go
@@ -71,13 +71,12 @@ func NewPrivkeyFileAuthMethod(filename string) *PrivkeyFileAuthMethod {
 // ~/.ssh) that OpenSSH tries by default when no identity file is explicitly
 // configured, following the order of ssh_config(5).
 var defaultPrivkeyBasenames = []string{
-	"id_dsa",
-	"id_ecdsa",
-	"id_ecdsa_sk",
 	"id_ed25519",
-	"id_ed25519_sk",
 	"id_rsa",
+	"id_ecdsa",
 	"id_xmss",
+	"id_ed25519_sk",
+	"id_ecdsa_sk",
 }
 
 // NewDefaultPrivkeyFileAuthMethods returns one PrivkeyFileAuthMethod per

--- a/client_auth_test.go
+++ b/client_auth_test.go
@@ -50,11 +50,11 @@ func TestNewDefaultPrivkeyFileAuthMethods_ExistingKeys(t *testing.T) {
 	if len(methods) != 3 {
 		t.Fatalf("expected 3 default auth methods, got %d", len(methods))
 	}
-	// order must follow the OpenSSH default order
+	// order must follow the default key order
 	expected := []string{
-		path.Join(sshDir, "id_ecdsa"),
 		path.Join(sshDir, "id_ed25519"),
 		path.Join(sshDir, "id_rsa"),
+		path.Join(sshDir, "id_ecdsa"),
 	}
 	for i, method := range methods {
 		if method.Filename() != expected[i] {

--- a/client_auth_test.go
+++ b/client_auth_test.go
@@ -1,0 +1,64 @@
+package ssh3
+
+import (
+	"os"
+	"path"
+	"testing"
+)
+
+func TestNewDefaultPrivkeyFileAuthMethods_NoSSHDir(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+
+	methods := NewDefaultPrivkeyFileAuthMethods()
+	if len(methods) != 0 {
+		t.Fatalf("expected no default auth methods when ~/.ssh does not exist, got %d", len(methods))
+	}
+}
+
+func TestNewDefaultPrivkeyFileAuthMethods_EmptySSHDir(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+	if err := os.MkdirAll(path.Join(tmpDir, ".ssh"), 0700); err != nil {
+		t.Fatalf("could not create ~/.ssh: %s", err)
+	}
+
+	methods := NewDefaultPrivkeyFileAuthMethods()
+	if len(methods) != 0 {
+		t.Fatalf("expected no default auth methods when ~/.ssh is empty, got %d", len(methods))
+	}
+}
+
+func TestNewDefaultPrivkeyFileAuthMethods_ExistingKeys(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+	sshDir := path.Join(tmpDir, ".ssh")
+	if err := os.MkdirAll(sshDir, 0700); err != nil {
+		t.Fatalf("could not create ~/.ssh: %s", err)
+	}
+	for _, name := range []string{"id_rsa", "id_ed25519", "id_ecdsa"} {
+		if err := os.WriteFile(path.Join(sshDir, name), []byte("test"), 0600); err != nil {
+			t.Fatalf("could not write %s: %s", name, err)
+		}
+	}
+	// a directory named like a default key must not be considered as a key
+	if err := os.MkdirAll(path.Join(sshDir, "id_dsa"), 0700); err != nil {
+		t.Fatalf("could not create id_dsa directory: %s", err)
+	}
+
+	methods := NewDefaultPrivkeyFileAuthMethods()
+	if len(methods) != 3 {
+		t.Fatalf("expected 3 default auth methods, got %d", len(methods))
+	}
+	// order must follow the OpenSSH default order
+	expected := []string{
+		path.Join(sshDir, "id_ecdsa"),
+		path.Join(sshDir, "id_ed25519"),
+		path.Join(sshDir, "id_rsa"),
+	}
+	for i, method := range methods {
+		if method.Filename() != expected[i] {
+			t.Errorf("method %d: expected %s, got %s", i, expected[i], method.Filename())
+		}
+	}
+}

--- a/cmd/sshoq.go
+++ b/cmd/sshoq.go
@@ -386,7 +386,7 @@ func cliIdentityOptionNames(cliOptions map[client_config.OptionName]client_confi
 		if optionParser.OptionConfigName() != "IdentityFile" {
 			continue
 		}
-		if _, specified := cliOptions[optionName]; specified {
+		if opt, specified := cliOptions[optionName]; specified && opt != nil {
 			identityOptions[optionName] = true
 		}
 	}
@@ -490,9 +490,14 @@ func ClientMain() int {
 	}
 
 	cliOptions := make(map[client_config.OptionName]client_config.Option)
-	// gather the parsed CLI options
+	// gather the parsed CLI options (only options that were actually provided
+	// on the command line; for unset flags, parsedOption is nil and must not
+	// be stored, otherwise it would shadow config-derived options and be
+	// mistaken for an explicitly specified identity)
 	for _, v := range flagValues {
-		cliOptions[v.pluginOptionName] = v.parsedOption
+		if v.parsedOption != nil {
+			cliOptions[v.pluginOptionName] = v.parsedOption
+		}
 	}
 
 	useOIDC := *issuerUrl != ""

--- a/cmd/sshoq.go
+++ b/cmd/sshoq.go
@@ -309,10 +309,10 @@ func getConfigOptions(hostUrl *url.URL, sshConfig *ssh_config.Config, optionPars
 		if configUrlPath != "" {
 			urlPath = configUrlPath
 		} else {
-			// default path 
+			// default path
 			urlPath = "sshoq-server"
 		}
-		
+
 	}
 	return client_config.NewConfig(username, hostname, port, urlPath, configAuthMethods, pluginOptions)
 }
@@ -345,11 +345,52 @@ func getConnectionMaterialFromURL(hostUrl *url.URL, sshConfig *ssh_config.Config
 		pluginOptionsFromConfig[k] = v
 	}
 
-	options, err := client_config.NewConfig(configOptions.Username(), configOptions.Hostname(), configOptions.Port(), configOptions.UrlPath(), authMethods, configOptions.Options())
+	// If an identity file is explicitly provided on the command line (e.g.
+	// via -i), it takes precedence over everything else and is the only
+	// authentication method that should be used: config-derived IdentityFile
+	// entries and their auth methods are discarded so that they cannot be
+	// used (for instance as an agent-based pubkey auth fallback).
+	if cliIdentityOptions := cliIdentityOptionNames(cliOptions, optionParsers); len(cliIdentityOptions) > 0 {
+		authMethods = cliAuthMethods
+		for optionName, optionParser := range optionParsers {
+			if optionParser.OptionConfigName() != "IdentityFile" {
+				continue
+			}
+			if _, fromCLI := cliIdentityOptions[optionName]; !fromCLI {
+				delete(pluginOptionsFromConfig, optionName)
+			}
+		}
+	} else if len(authMethods) == 0 {
+		// When no identity is explicitly configured (neither via CLI flags
+		// such as -i or -use-password, nor via IdentityFile entries in the
+		// ssh config), try the default private keys from ~/.ssh (e.g.
+		// ~/.ssh/id_rsa, ~/.ssh/id_ed25519, ...) like OpenSSH does.
+		for _, defaultMethod := range ssh3.NewDefaultPrivkeyFileAuthMethods() {
+			authMethods = append(authMethods, defaultMethod)
+		}
+	}
+
+	options, err := client_config.NewConfig(configOptions.Username(), configOptions.Hostname(), configOptions.Port(), configOptions.UrlPath(), authMethods, pluginOptionsFromConfig)
 	if err != nil {
 		return nil, nil, fmt.Errorf("could not instantiate invalid options: %s", err)
 	}
 	return agentClient, options, nil
+}
+
+// cliIdentityOptionNames returns the set of option names whose value was
+// provided on the command line and whose parser is backed by the
+// "IdentityFile" config keyword (e.g. the -i flag for private key files).
+func cliIdentityOptionNames(cliOptions map[client_config.OptionName]client_config.Option, optionParsers map[client_config.OptionName]client_config.OptionParser) map[client_config.OptionName]bool {
+	identityOptions := make(map[client_config.OptionName]bool)
+	for optionName, optionParser := range optionParsers {
+		if optionParser.OptionConfigName() != "IdentityFile" {
+			continue
+		}
+		if _, specified := cliOptions[optionName]; specified {
+			identityOptions[optionName] = true
+		}
+	}
+	return identityOptions
 }
 
 type FlagValue struct {
@@ -427,7 +468,7 @@ func ClientMain() int {
 	} else {
 		util.ConfigureLogger(os.Getenv("SSH3_LOG_LEVEL"))
 	}
-	
+
 	cliParsers, err := internal.GetPluginsCLIArgs()
 	if err != nil {
 		log.Error().Msgf("error when retrieving plugins-defined CLI args: %s", err)
@@ -713,10 +754,10 @@ func ClientMain() int {
 		}
 		qconn, status := setupQUICConnection(ctx, *insecure, keyLog, ssh3Dir, pool, knownHostsPath, knownHosts, oidcConfig, proxyOptions, nil, tty)
 
-		if qconn == nil && status != 0{
+		if qconn == nil && status != 0 {
 			log.Error().Msgf("could not setup transport for proxy client.")
 			return status
-		} else if (qconn == nil && status == 0) {
+		} else if qconn == nil && status == 0 {
 			// reconnect due to likely first time self signed cert error
 			log.Info().Msgf("re-parsing known hosts and reconnecting via jump host now..")
 			knownHosts, _, parsingErr := ssh3.ParseKnownHosts(knownHostsPath)
@@ -727,7 +768,7 @@ func ClientMain() int {
 			qconn, status = setupQUICConnection(ctx, *insecure, keyLog, ssh3Dir, pool, knownHostsPath, knownHosts, oidcConfig, proxyOptions, nil, tty)
 		}
 		// reconnect status
-		if qconn == nil{
+		if qconn == nil {
 			log.Error().Msgf("Still could not connect through proxy client.")
 			return status
 		}
@@ -764,16 +805,16 @@ func ClientMain() int {
 	qconn, status := setupQUICConnection(ctx, *insecure, keyLog, ssh3Dir, pool, knownHostsPath, knownHosts, oidcConfig, options, proxyAddress, tty)
 
 	if qconn == nil && status != 0 {
-			log.Error().Msgf("could not setup transport for client.")
-			return status
-	} else if (qconn == nil && status == 0) {
+		log.Error().Msgf("could not setup transport for client.")
+		return status
+	} else if qconn == nil && status == 0 {
 		// reconnect
 		log.Info().Msgf("re-parsing known hosts and reconnecting now..")
 		knownHosts, _, parsingErr := ssh3.ParseKnownHosts(knownHostsPath)
-			if parsingErr != nil {
-				log.Error().Msgf("Error parsing known hosts file (%s): %s", knownHostsPath, parsingErr)
-				return -1
-			}
+		if parsingErr != nil {
+			log.Error().Msgf("Error parsing known hosts file (%s): %s", knownHostsPath, parsingErr)
+			return -1
+		}
 		qconn, status = setupQUICConnection(ctx, *insecure, keyLog, ssh3Dir, pool, knownHostsPath, knownHosts, oidcConfig, options, proxyAddress, tty)
 	}
 	if qconn == nil {
@@ -782,7 +823,6 @@ func ClientMain() int {
 		}
 		return status
 	}
-
 
 	roundTripper := &http3.RoundTripper{
 		EnableDatagrams: true,

--- a/cmd/sshoq_test.go
+++ b/cmd/sshoq_test.go
@@ -1,0 +1,133 @@
+package cmd
+
+import (
+	"net/url"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/h4sh5/sshoq"
+	client_pubkey_authentication "github.com/h4sh5/sshoq/auth/plugins/pubkey_authentication/client"
+	"github.com/h4sh5/sshoq/client/config"
+	"github.com/kevinburke/ssh_config"
+)
+
+func testOptionParsers() map[config.OptionName]config.OptionParser {
+	return map[config.OptionName]config.OptionParser{
+		client_pubkey_authentication.PRIVKEY_OPTION_NAME: &client_pubkey_authentication.PrivkeyOptionParser{},
+		client_pubkey_authentication.PUBKEY_OPTION_NAME:  &client_pubkey_authentication.PubkeyOptionParser{},
+	}
+}
+
+// When no identity is configured anywhere, the default private keys from
+// ~/.ssh must be used.
+func TestGetConnectionMaterialFromURL_DefaultKeysFromDotSSH(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+	sshDir := path.Join(tmpDir, ".ssh")
+	if err := os.MkdirAll(sshDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path.Join(sshDir, "id_rsa"), []byte("test"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	hostUrl, err := url.Parse("https://example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, options, err := getConnectionMaterialFromURL(hostUrl, nil, nil, nil, testOptionParsers())
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	methods := options.AuthMethods()
+	if len(methods) != 1 {
+		t.Fatalf("expected exactly 1 default auth method, got %d", len(methods))
+	}
+	privkeyMethod, ok := methods[0].(*ssh3.PrivkeyFileAuthMethod)
+	if !ok {
+		t.Fatalf("expected *ssh3.PrivkeyFileAuthMethod, got %T", methods[0])
+	}
+	expected := path.Join(sshDir, "id_rsa")
+	if privkeyMethod.Filename() != expected {
+		t.Errorf("expected %s, got %s", expected, privkeyMethod.Filename())
+	}
+}
+
+// When no identity is configured and ~/.ssh contains no key, no auth method
+// must be produced (the connection will fail later with a clean error).
+func TestGetConnectionMaterialFromURL_NoDefaultKeys(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+
+	hostUrl, err := url.Parse("https://example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, options, err := getConnectionMaterialFromURL(hostUrl, nil, nil, nil, testOptionParsers())
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if len(options.AuthMethods()) != 0 {
+		t.Fatalf("expected no auth methods, got %d", len(options.AuthMethods()))
+	}
+}
+
+// When -i is provided on the command line, it must be the only
+// identity-related auth material: default keys from ~/.ssh are not used,
+// config IdentityFile entries are discarded and config-derived auth methods
+// are dropped.
+func TestGetConnectionMaterialFromURL_ICLIOptionIsOnlyMethod(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+	sshDir := path.Join(tmpDir, ".ssh")
+	if err := os.MkdirAll(sshDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path.Join(sshDir, "id_rsa"), []byte("test"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	// the ssh config also references an IdentityFile
+	configContent := "Host example.com\n  HostName example.com\n  Port 443\n  User testuser\n  IdentityFile /tmp/config_key\n"
+	sshCfg, err := ssh_config.DecodeBytes([]byte(configContent))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cliPrivkeyOption, err := (&client_pubkey_authentication.PrivkeyOptionParser{}).Parse([]string{"/tmp/cli_key"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	cliOptions := map[config.OptionName]config.Option{
+		client_pubkey_authentication.PRIVKEY_OPTION_NAME: cliPrivkeyOption,
+	}
+
+	hostUrl, err := url.Parse("https://example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, options, err := getConnectionMaterialFromURL(hostUrl, sshCfg, nil, cliOptions, testOptionParsers())
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	// no legacy auth method (neither from the ssh config nor from ~/.ssh)
+	// must survive when -i is used
+	if len(options.AuthMethods()) != 0 {
+		t.Errorf("expected no legacy auth methods when -i is used, got %d", len(options.AuthMethods()))
+	}
+
+	// the only IdentityFile-backed option that must remain is the CLI one
+	for name := range options.Options() {
+		switch name {
+		case client_pubkey_authentication.PRIVKEY_OPTION_NAME:
+			// ok: the CLI-provided identity file
+		case client_pubkey_authentication.PUBKEY_OPTION_NAME:
+			t.Errorf("config-derived PUBKEY option should have been removed when -i is used")
+		default:
+			t.Errorf("unexpected option %s", name)
+		}
+	}
+}

--- a/cmd/sshoq_test.go
+++ b/cmd/sshoq_test.go
@@ -74,6 +74,42 @@ func TestGetConnectionMaterialFromURL_NoDefaultKeys(t *testing.T) {
 	}
 }
 
+// Unset plugin flags are gathered as nil values in cliOptions (see
+// ClientMain): they must NOT be mistaken for an explicitly specified
+// identity, otherwise default ~/.ssh keys would not be tried.
+func TestGetConnectionMaterialFromURL_NilCLIOptionsDoNotSuppressDefaults(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+	sshDir := path.Join(tmpDir, ".ssh")
+	if err := os.MkdirAll(sshDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path.Join(sshDir, "id_ed25519"), []byte("test"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	// simulate unset plugin flags: present in the map but with a nil value
+	cliOptions := map[config.OptionName]config.Option{
+		client_pubkey_authentication.PRIVKEY_OPTION_NAME: nil,
+		client_pubkey_authentication.PUBKEY_OPTION_NAME:  nil,
+	}
+
+	hostUrl, err := url.Parse("https://example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, options, err := getConnectionMaterialFromURL(hostUrl, nil, nil, cliOptions, testOptionParsers())
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if len(options.AuthMethods()) != 1 {
+		t.Fatalf("expected 1 default auth method, got %d", len(options.AuthMethods()))
+	}
+	if m, ok := options.AuthMethods()[0].(*ssh3.PrivkeyFileAuthMethod); !ok || m.Filename() != path.Join(sshDir, "id_ed25519") {
+		t.Errorf("expected default key %s to be tried, got %v", path.Join(sshDir, "id_ed25519"), options.AuthMethods()[0])
+	}
+}
+
 // When -i is provided on the command line, it must be the only
 // identity-related auth material: default keys from ~/.ssh are not used,
 // config IdentityFile entries are discarded and config-derived auth methods

--- a/integration_tests/sshoq_test.go
+++ b/integration_tests/sshoq_test.go
@@ -590,7 +590,7 @@ var _ = Describe("Testing the sshoq cli", func() {
 					Expect(err).ToNot(HaveOccurred())
 					Eventually(session).Should(Exit())
 					Eventually(session).ShouldNot(Exit(0))
-					Eventually(string(session.Wait().Err.Contents())).Should(ContainSubstring("unauthorized"))
+					Eventually(string(session.Wait().Err.Contents())).Should(ContainSubstring("Unauthorized"))
 				})
 			})
 		})


### PR DESCRIPTION
    fix: try each ~/.ssh key in sequence like OpenSSH, with server-level fallback

    Restructure client.Dial to collect all auth attempts (from both plugins
    and legacy identity methods) and try each one against the server in
    sequence, rather than producing one identity, attempting once, and
    failing immediately on Unauthorized.

    When a key is rejected by the server (Unauthorized), the client now
    continues to the next key and prints the server rejection, exactly like
    OpenSSH. This is essential for the default ~/.ssh key feature: if
    id_ed25519 is not authorized but id_rsa is, the client falls back.

    Also fixed a critical bug: unset plugin CLI flags were stored as nil
    in cliOptions, which caused cliIdentityOptionNames to think -i was
    specified even when it was not, suppressing default ~/.ssh keys.
    Now only flags with non-nil parsedOption are stored, and the helper
    defensively checks for nil values.