### PR TITLE
feat: add -scp mode for non-interactive file transfer

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,24 @@ To use sftp mode on the client, run this to drop into a SFTP shell:
 
 Type `help` in the `sftp>` prompt to see what commands are available.
 
+For non-interactive, scp-style copy, use `-scp`. Since `:` is already used for the port designation in the connection URL, the remote path is separated from the sshoq server URL with `%`. Add `-r` to copy directories recursively:
+
+Upload a local file to a remote path:
+
+`sshoq -scp localfile user@remote:443/sshoq-server%/tmp/remotefile`
+
+Upload a local folder recursively to the remote host:
+
+`sshoq -scp -r ./localfolder user@remote:443/sshoq-server%/tmp/`
+
+Download a remote file to the local directory:
+
+`sshoq -scp user@remote:443/sshoq-server%.ssh/authorized_keys .`
+
+Download a remote folder recursively to the local directory:
+
+`sshoq -scp -r user@remote:443/sshoq-server%/etc/nginx .`
+
 ### Local port forwarding
 
 As a SSH compatibility shortcut, `-L` is the same as `-forward-tcp`

--- a/cmd/sshoq.go
+++ b/cmd/sshoq.go
@@ -437,6 +437,38 @@ func (v *FlagValue) IsBoolFlag() bool {
 	return v.CLIOptionParser.IsBoolFlag()
 }
 
+// parseScpArgs splits the two scp-mode arguments into a transfer direction and
+// the local/remote paths. The remote argument uses '%' as the separator between
+// the sshoq server URL and the remote path, since ':' is already used for the
+// port designation
+// (e.g. user@host:443/sshoq-server%/tmp/remotefile). When the remote argument
+// is args[0] the transfer is a download, otherwise it is an upload.
+func parseScpArgs(args []string) (upload bool, localPath, remotePath, urlParam string, err error) {
+	if len(args) != 2 {
+		return false, "", "", "", fmt.Errorf("scp mode requires exactly two arguments: <local-path> <remote-url> (upload) or <remote-url> <local-path> (download)")
+	}
+	remoteIdx := -1
+	for i, arg := range args {
+		if strings.Contains(arg, "%") {
+			remoteIdx = i
+			break
+		}
+	}
+	if remoteIdx == -1 {
+		return false, "", "", "", fmt.Errorf("could not find the remote path separator '%%' in the arguments: the remote argument must look like user@host:443/sshoq-server%%/remote/path")
+	}
+	urlPathParts := strings.SplitN(args[remoteIdx], "%", 2)
+	if urlPathParts[0] == "" || urlPathParts[1] == "" {
+		return false, "", "", "", fmt.Errorf("invalid remote argument %q: expected user@host:port/sshoq-server%%/remote/path", args[remoteIdx])
+	}
+	if remoteIdx == 1 {
+		// upload: local source is args[0], remote destination is args[1]
+		return true, args[0], urlPathParts[1], urlPathParts[0], nil
+	}
+	// download: remote source is args[0], local destination is args[1]
+	return false, args[1], urlPathParts[1], urlPathParts[0], nil
+}
+
 func ClientMain() int {
 	internal.CloseClientPluginsRegistry()
 	internal.CloseServerPluginsRegistry()
@@ -460,6 +492,8 @@ func ClientMain() int {
 	flag.StringVar(reverseTCP, "R", *reverseTCP, "alias for -reverse-tcp")
 	proxyJump := flag.String("proxy-jump", "", "if set, performs a proxy jump using the specified remote host as proxy (requires server with version >= 0.1.5)")
 	sftpMode := flag.Bool("sftp", false, "if set, start an interactive SFTP session")
+	scpMode := flag.Bool("scp", false, "if set, copy files to or from the remote host non-interactively, like scp")
+	scpRecursive := flag.Bool("r", false, "if set with -scp, recursively copy directories")
 
 	var flagValues []*FlagValue
 	log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr})
@@ -535,11 +569,29 @@ func ClientMain() int {
 		tty = nil
 	}
 
+	// In scp mode, one of the two arguments is the remote URL. It uses '%' to
+	// separate the sshoq server URL from the remote path, since ':' is already
+	// used for the port designation
+	// (e.g. user@host:443/sshoq-server%/tmp/remotefile).
+	var scpUpload bool
+	var scpLocalPath, scpRemotePath string
 	urlFromParam := args[0]
+	command := args[1:]
+	if *scpMode {
+		if *sftpMode {
+			log.Error().Msgf("cannot use -sftp and -scp at the same time")
+			return -1
+		}
+		var err error
+		scpUpload, scpLocalPath, scpRemotePath, urlFromParam, err = parseScpArgs(args)
+		if err != nil {
+			log.Error().Msgf("%s", err)
+			return -1
+		}
+	}
 	if !strings.HasPrefix(urlFromParam, "https://") {
 		urlFromParam = fmt.Sprintf("https://%s", urlFromParam)
 	}
-	command := args[1:]
 
 	var localUDPAddr *net.UDPAddr = nil
 	var remoteUDPAddr *net.UDPAddr = nil
@@ -980,6 +1032,8 @@ func ClientMain() int {
 
 	if *sftpMode {
 		err = sshoqsftp.RunInteractiveClient(c)
+	} else if *scpMode {
+		err = sshoqsftp.RunScpClient(c, scpUpload, *scpRecursive, scpLocalPath, scpRemotePath)
 	} else {
 		err = c.RunSession(tty, *forwardSSHAgent, *forcePTYAlloc, command...)
 	}

--- a/cmd/sshoq_test.go
+++ b/cmd/sshoq_test.go
@@ -167,3 +167,111 @@ func TestGetConnectionMaterialFromURL_ICLIOptionIsOnlyMethod(t *testing.T) {
 		}
 	}
 }
+
+// --- scp argument parsing tests ---
+
+func TestParseScpArgsUpload(t *testing.T) {
+	upload, localPath, remotePath, urlParam, err := parseScpArgs([]string{"localfile", "user@remote:443/sshoq-server%/tmp/remotefile"})
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if !upload {
+		t.Errorf("expected upload direction, got download")
+	}
+	if localPath != "localfile" {
+		t.Errorf("expected localPath localfile, got %s", localPath)
+	}
+	if remotePath != "/tmp/remotefile" {
+		t.Errorf("expected remotePath /tmp/remotefile, got %s", remotePath)
+	}
+	if urlParam != "user@remote:443/sshoq-server" {
+		t.Errorf("expected urlParam user@remote:443/sshoq-server, got %s", urlParam)
+	}
+}
+
+func TestParseScpArgsDownload(t *testing.T) {
+	upload, localPath, remotePath, urlParam, err := parseScpArgs([]string{"user@remote:443/sshoq-server%.ssh/authorized_keys", "."})
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if upload {
+		t.Errorf("expected download direction, got upload")
+	}
+	if localPath != "." {
+		t.Errorf("expected localPath ., got %s", localPath)
+	}
+	if remotePath != ".ssh/authorized_keys" {
+		t.Errorf("expected remotePath .ssh/authorized_keys, got %s", remotePath)
+	}
+	if urlParam != "user@remote:443/sshoq-server" {
+		t.Errorf("expected urlParam user@remote:443/sshoq-server, got %s", urlParam)
+	}
+}
+
+func TestParseScpArgsRecursiveDownload(t *testing.T) {
+	upload, localPath, remotePath, urlParam, err := parseScpArgs([]string{"user@remote:443/sshoq-server%/etc/nginx", "."})
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if upload {
+		t.Errorf("expected download direction, got upload")
+	}
+	if localPath != "." {
+		t.Errorf("expected localPath ., got %s", localPath)
+	}
+	if remotePath != "/etc/nginx" {
+		t.Errorf("expected remotePath /etc/nginx, got %s", remotePath)
+	}
+	if urlParam != "user@remote:443/sshoq-server" {
+		t.Errorf("expected urlParam user@remote:443/sshoq-server, got %s", urlParam)
+	}
+}
+
+func TestParseScpArgsWrongArgCount(t *testing.T) {
+	for _, args := range [][]string{
+		{},
+		{"onlyone"},
+		{"a", "b", "c"},
+	} {
+		if _, _, _, _, err := parseScpArgs(args); err == nil {
+			t.Errorf("expected error for args %v", args)
+		}
+	}
+}
+
+func TestParseScpArgsNoSeparator(t *testing.T) {
+	if _, _, _, _, err := parseScpArgs([]string{"localfile", "user@remote:443/sshoq-server"}); err == nil {
+		t.Error("expected error when no '%' separator is present")
+	}
+}
+
+func TestParseScpArgsEmptyUrlPart(t *testing.T) {
+	if _, _, _, _, err := parseScpArgs([]string{"localfile", "%/tmp/remotefile"}); err == nil {
+		t.Error("expected error when the URL part is empty")
+	}
+}
+
+func TestParseScpArgsEmptyRemotePath(t *testing.T) {
+	if _, _, _, _, err := parseScpArgs([]string{"localfile", "user@remote:443/sshoq-server%"}); err == nil {
+		t.Error("expected error when the remote path is empty")
+	}
+}
+
+func TestParseScpArgsRemotePathContainsPercent(t *testing.T) {
+	upload, localPath, remotePath, urlParam, err := parseScpArgs([]string{"localfile", "user@remote:443/sshoq-server%/tmp/100%25done"})
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if !upload {
+		t.Errorf("expected upload direction")
+	}
+	if localPath != "localfile" {
+		t.Errorf("expected localPath localfile, got %s", localPath)
+	}
+	if remotePath != "/tmp/100%25done" {
+		t.Errorf("expected remotePath /tmp/100%%25done, got %s", remotePath)
+	}
+	if urlParam != "user@remote:443/sshoq-server" {
+		t.Errorf("expected urlParam user@remote:443/sshoq-server, got %s", urlParam)
+	}
+}

--- a/integration_tests/sshoq_test.go
+++ b/integration_tests/sshoq_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"path/filepath"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -70,6 +71,19 @@ var _ = BeforeSuite(func() {
 		// run them is they are enabled explicitly.
 		ssh3ServerPath, err = BuildWithEnvironment("../cmd/sshoq-server/main.go", []string{fmt.Sprintf("CGO_ENABLED=%s", os.Getenv("CGO_ENABLED"))})
 		Expect(err).ToNot(HaveOccurred())
+
+		// The SFTP handler is served in a forked child process that runs with
+		// the authenticated user's UID/GID (see sftp.ServeChannel), so the
+		// server binary must be reachable and executable by that user. gexec
+		// compiles the binary into a chain of 0700 temp directories
+		// (/tmp/gexec_artifacts*/g*), which would prevent the child from being
+		// spawned (fork/exec: permission denied); open up every ancestor
+		// directory and the binary itself so SFTP sessions (e.g. -sftp or
+		// -scp) can run in the integration tests.
+		for dir := filepath.Dir(ssh3ServerPath); dir != "/" && dir != "."; dir = filepath.Dir(dir) {
+			Expect(os.Chmod(dir, 0o755)).To(Succeed())
+		}
+		Expect(os.Chmod(ssh3ServerPath, 0o755)).To(Succeed())
 		serverCommand = exec.Command(ssh3ServerPath,
 			"-bind", serverBind,
 			"-v",
@@ -447,6 +461,178 @@ var _ = Describe("Testing the sshoq cli", func() {
 						testTCPPortForwarding(8082, false, &net.TCPAddr{IP: net.ParseIP("::1"), Port: 9090}, "hello from client", "hello from server", "-forward-tcp")
 						testTCPPortForwarding(8093, false, &net.TCPAddr{IP: net.ParseIP("::1"), Port: 9090}, "hello from client", "hello from server", "-reverse-tcp")
 					})
+				})
+			})
+
+			Context("scp file transfer", func() {
+				// scpRemoteURL builds a client connection URL with the remote path
+				// appended after the '%' separator (':' is used for the port), e.g.
+				// ssh3-testuser@127.0.0.1:4433/sshoq-tests%/home/ssh3-testuser/x.txt.
+				// The connection URL is already part of the string, so scp client
+				// args are built manually instead of via getClientArgs (which
+				// appends a bare connection URL as the last argument).
+				scpRemoteURL := func(bind, remotePath string) string {
+					return fmt.Sprintf("%s@%s%s%%%s", username, bind, DEFAULT_URL_PATH, remotePath)
+				}
+
+				It("uploads a single file with -scp", func() {
+					localFile := filepath.Join(GinkgoT().TempDir(), "localfile.txt")
+					err := os.WriteFile(localFile, []byte("hello from scp upload"), 0644)
+					Expect(err).ToNot(HaveOccurred())
+
+					remoteFile := fmt.Sprintf("/home/%s/scp-uploaded-%d.txt", username, time.Now().UnixNano())
+					defer os.RemoveAll(remoteFile)
+
+					clientArgs := []string{
+						"-v", "-insecure", "-i", rsaPrivKeyPath,
+						"-scp",
+						localFile,
+						scpRemoteURL(serverBind, remoteFile),
+					}
+					command := exec.Command(ssh3Path, clientArgs...)
+					session, err := Start(command, GinkgoWriter, GinkgoWriter)
+					Expect(err).ToNot(HaveOccurred())
+					Eventually(session).Should(Exit(0))
+					Eventually(session).Should(Say("Uploaded .*localfile.txt"))
+
+					content, err := os.ReadFile(remoteFile)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(string(content)).To(Equal("hello from scp upload"))
+				})
+
+				It("uploads a directory recursively with -scp -r", func() {
+					localDir := filepath.Join(GinkgoT().TempDir(), "scp-folder")
+					err := os.MkdirAll(filepath.Join(localDir, "sub"), 0755)
+					Expect(err).ToNot(HaveOccurred())
+					err = os.WriteFile(filepath.Join(localDir, "a.txt"), []byte("alpha"), 0644)
+					Expect(err).ToNot(HaveOccurred())
+					err = os.WriteFile(filepath.Join(localDir, "sub", "b.txt"), []byte("beta"), 0644)
+					Expect(err).ToNot(HaveOccurred())
+
+					// the trailing '/' makes the remote folder be copied into the
+					// destination under its own basename, like scp -r
+					remoteParent := fmt.Sprintf("/home/%s/scp-dest-%d/", username, time.Now().UnixNano())
+					defer os.RemoveAll(remoteParent)
+
+					clientArgs := []string{
+						"-v", "-insecure", "-i", rsaPrivKeyPath,
+						"-scp", "-r",
+						localDir,
+						scpRemoteURL(serverBind, remoteParent),
+					}
+					command := exec.Command(ssh3Path, clientArgs...)
+					session, err := Start(command, GinkgoWriter, GinkgoWriter)
+					Expect(err).ToNot(HaveOccurred())
+					Eventually(session).Should(Exit(0))
+
+					content, err := os.ReadFile(filepath.Join(remoteParent, "scp-folder", "a.txt"))
+					Expect(err).ToNot(HaveOccurred())
+					Expect(string(content)).To(Equal("alpha"))
+					content, err = os.ReadFile(filepath.Join(remoteParent, "scp-folder", "sub", "b.txt"))
+					Expect(err).ToNot(HaveOccurred())
+					Expect(string(content)).To(Equal("beta"))
+				})
+
+				It("downloads a single file with -scp", func() {
+					// first place a remote file via an scp upload, then fetch it back
+					localSrc := filepath.Join(GinkgoT().TempDir(), "src.txt")
+					err := os.WriteFile(localSrc, []byte("round trip content"), 0644)
+					Expect(err).ToNot(HaveOccurred())
+
+					remoteFile := fmt.Sprintf("/home/%s/scp-roundtrip-%d.txt", username, time.Now().UnixNano())
+					defer os.RemoveAll(remoteFile)
+
+					uploadArgs := []string{
+						"-v", "-insecure", "-i", rsaPrivKeyPath,
+						"-scp",
+						localSrc,
+						scpRemoteURL(serverBind, remoteFile),
+					}
+					upSession, err := Start(exec.Command(ssh3Path, uploadArgs...), GinkgoWriter, GinkgoWriter)
+					Expect(err).ToNot(HaveOccurred())
+					Eventually(upSession).Should(Exit(0))
+
+					localDir := GinkgoT().TempDir()
+					// for a download, the remote URL comes first and the local
+					// destination second, so the args are built manually
+					clientArgs := []string{
+						"-v", "-insecure", "-i", rsaPrivKeyPath,
+						"-scp",
+						scpRemoteURL(serverBind, remoteFile),
+						localDir,
+					}
+					command := exec.Command(ssh3Path, clientArgs...)
+					session, err := Start(command, GinkgoWriter, GinkgoWriter)
+					Expect(err).ToNot(HaveOccurred())
+					Eventually(session).Should(Exit(0))
+					Eventually(session).Should(Say("Downloaded .*scp-roundtrip-"))
+
+					// the downloaded file keeps the remote basename, like scp
+					content, err := os.ReadFile(filepath.Join(localDir, filepath.Base(remoteFile)))
+					Expect(err).ToNot(HaveOccurred())
+					Expect(string(content)).To(Equal("round trip content"))
+				})
+
+				It("downloads a directory recursively with -scp -r", func() {
+					// create a remote directory tree via an scp upload, then fetch it back
+					localSrcDir := filepath.Join(GinkgoT().TempDir(), "remote-folder")
+					err := os.MkdirAll(filepath.Join(localSrcDir, "nested"), 0755)
+					Expect(err).ToNot(HaveOccurred())
+					err = os.WriteFile(filepath.Join(localSrcDir, "one.txt"), []byte("first"), 0644)
+					Expect(err).ToNot(HaveOccurred())
+					err = os.WriteFile(filepath.Join(localSrcDir, "nested", "two.txt"), []byte("second"), 0644)
+					Expect(err).ToNot(HaveOccurred())
+
+					remoteParent := fmt.Sprintf("/home/%s/scp-rdest-%d/", username, time.Now().UnixNano())
+					defer os.RemoveAll(remoteParent)
+
+					uploadArgs := []string{
+						"-v", "-insecure", "-i", rsaPrivKeyPath,
+						"-scp", "-r",
+						localSrcDir,
+						scpRemoteURL(serverBind, remoteParent),
+					}
+					upSession, err := Start(exec.Command(ssh3Path, uploadArgs...), GinkgoWriter, GinkgoWriter)
+					Expect(err).ToNot(HaveOccurred())
+					Eventually(upSession).Should(Exit(0))
+
+					localDir := GinkgoT().TempDir()
+					clientArgs := []string{
+						"-v", "-insecure", "-i", rsaPrivKeyPath,
+						"-scp", "-r",
+						scpRemoteURL(serverBind, filepath.Join(remoteParent, "remote-folder")),
+						localDir,
+					}
+					command := exec.Command(ssh3Path, clientArgs...)
+					session, err := Start(command, GinkgoWriter, GinkgoWriter)
+					Expect(err).ToNot(HaveOccurred())
+					Eventually(session).Should(Exit(0))
+
+					content, err := os.ReadFile(filepath.Join(localDir, "remote-folder", "one.txt"))
+					Expect(err).ToNot(HaveOccurred())
+					Expect(string(content)).To(Equal("first"))
+					content, err = os.ReadFile(filepath.Join(localDir, "remote-folder", "nested", "two.txt"))
+					Expect(err).ToNot(HaveOccurred())
+					Expect(string(content)).To(Equal("second"))
+				})
+
+				It("returns a useful error when SFTP is disabled on the server", func() {
+					localFile := filepath.Join(GinkgoT().TempDir(), "localfile.txt")
+					err := os.WriteFile(localFile, []byte("x"), 0644)
+					Expect(err).ToNot(HaveOccurred())
+
+					remoteFile := fmt.Sprintf("/home/%s/scp-disabled-%d.txt", username, time.Now().UnixNano())
+					clientArgs := []string{
+						"-v", "-insecure", "-i", rsaPrivKeyPath,
+						"-scp",
+						localFile,
+						scpRemoteURL(serverBindSFTPDisabled, remoteFile),
+					}
+					command := exec.Command(ssh3Path, clientArgs...)
+					session, err := Start(command, GinkgoWriter, GinkgoWriter)
+					Expect(err).ToNot(HaveOccurred())
+					Eventually(session).Should(Exit(255))
+					Eventually(session.Err).Should(Say("could not open sftp channel: .*SFTP is disabled on the server"))
 				})
 			})
 

--- a/sftp/scp.go
+++ b/sftp/scp.go
@@ -1,0 +1,87 @@
+package sftp
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+
+	ssh3 "github.com/h4sh5/sshoq"
+	"github.com/h4sh5/sshoq/client"
+)
+
+// RunScpClient performs a single non-interactive copy between the local
+// machine and the remote host, reusing the SFTP channel and its request
+// protocol (the same channel the interactive -sftp mode uses). upload selects
+// the direction: when true, localPath is copied to remotePath; when false,
+// remotePath is copied to localPath. recursive enables directory transfers.
+func RunScpClient(c *client.Client, upload bool, recursive bool, localPath, remotePath string) error {
+	channel, err := c.OpenChannel("sftp", 30000, 0)
+	if err != nil {
+		return fmt.Errorf("could not open sftp channel: %w", err)
+	}
+	defer channel.Close()
+	if err := channel.WaitOpen(); err != nil {
+		return fmt.Errorf("could not open sftp channel: %w", err)
+	}
+
+	if upload {
+		return scpUpload(channel, recursive, localPath, remotePath)
+	}
+	return scpDownload(channel, recursive, remotePath, localPath)
+}
+
+// scpUpload copies a local file or directory to the remote host. Mirroring
+// scp semantics, when the remote target is an existing directory or ends with
+// a path separator, the source is copied into it under its own basename
+// (e.g. `scp -r ./dir host:/tmp/` copies to /tmp/dir).
+func scpUpload(channel ssh3.Channel, recursive bool, localPath, remotePath string) error {
+	info, err := os.Stat(localPath)
+	if err != nil {
+		return fmt.Errorf("cannot stat local path %s: %w", localPath, err)
+	}
+	if info.IsDir() && !recursive {
+		return fmt.Errorf("cannot upload directory %s: use -r for recursive copy", localPath)
+	}
+
+	if strings.HasSuffix(remotePath, "/") {
+		remotePath = path.Join(remotePath, filepath.Base(localPath))
+	} else if isRemoteDir(channel, remotePath) {
+		remotePath = path.Join(remotePath, filepath.Base(localPath))
+	}
+
+	if recursive {
+		return uploadRecursive(channel, localPath, remotePath)
+	}
+	return uploadFile(channel, localPath, remotePath)
+}
+
+// scpDownload copies a remote file or directory to the local machine.
+// Mirroring scp semantics, when the local target is an existing directory or
+// ends with a path separator, the remote source is copied into it under its
+// own basename (e.g. `scp -r host:/etc/nginx .` copies to ./nginx).
+func scpDownload(channel ssh3.Channel, recursive bool, remotePath, localPath string) error {
+	info, err := os.Stat(localPath)
+	if err == nil && info.IsDir() {
+		localPath = filepath.Join(localPath, filepath.Base(remotePath))
+	} else if strings.HasSuffix(localPath, string(filepath.Separator)) {
+		localPath = filepath.Join(localPath, filepath.Base(remotePath))
+	}
+
+	if recursive {
+		return downloadRecursive(channel, remotePath, localPath)
+	}
+	return downloadFile(channel, remotePath, localPath)
+}
+
+// isRemoteDir reports whether the remote path refers to an existing
+// directory. Errors (including a missing path) are reported as "not a
+// directory" so callers fall back to treating the target as a file name.
+func isRemoteDir(channel ssh3.Channel, remotePath string) bool {
+	resp, err := doRequest(channel, &Request{Cmd: "stat", Path: remotePath})
+	if err != nil || !resp.OK || resp.Info == nil {
+		return false
+	}
+	return resp.Info.IsDir
+}

--- a/sftp/scp_test.go
+++ b/sftp/scp_test.go
@@ -1,0 +1,295 @@
+package sftp
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestScpUploadFileToTrailingSlashTarget verifies that an upload whose remote
+// target ends with "/" copies the source into that directory under its own
+// basename, like scp (scp file host:/tmp/ copies to /tmp/file).
+func TestScpUploadFileToTrailingSlashTarget(t *testing.T) {
+	tmp := t.TempDir()
+	localPath := filepath.Join(tmp, "local.txt")
+	os.WriteFile(localPath, []byte("hello"), 0644)
+
+	ch := newMockChannel(
+		makeJSONDataMsg(&Response{ID: 1, OK: true}),
+	)
+
+	if err := scpUpload(ch, false, localPath, "/tmp/"); err != nil {
+		t.Fatalf("scpUpload error: %v", err)
+	}
+
+	if len(ch.Writes) != 1 {
+		t.Fatalf("expected 1 request, got %d", len(ch.Writes))
+	}
+	var got Request
+	if err := json.Unmarshal(ch.Writes[0], &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.Cmd != "put" || got.Path != "/tmp/local.txt" {
+		t.Fatalf("expected put /tmp/local.txt, got %s %q", got.Cmd, got.Path)
+	}
+}
+
+// TestScpUploadFileToExistingRemoteDir verifies that an upload whose remote
+// target is an existing directory (without a trailing slash) copies the source
+// into that directory under its own basename, like scp.
+func TestScpUploadFileToExistingRemoteDir(t *testing.T) {
+	tmp := t.TempDir()
+	localPath := filepath.Join(tmp, "local.txt")
+	os.WriteFile(localPath, []byte("hello"), 0644)
+
+	ch := newMockChannel(
+		makeJSONDataMsg(&Response{ID: 1, OK: true, Info: &FileInfo{Name: "remotedir", IsDir: true}}),
+		makeJSONDataMsg(&Response{ID: 2, OK: true}),
+	)
+
+	if err := scpUpload(ch, false, localPath, "/tmp/remotedir"); err != nil {
+		t.Fatalf("scpUpload error: %v", err)
+	}
+
+	if len(ch.Writes) != 2 {
+		t.Fatalf("expected 2 requests (stat + put), got %d", len(ch.Writes))
+	}
+	var statReq, putReq Request
+	if err := json.Unmarshal(ch.Writes[0], &statReq); err != nil {
+		t.Fatalf("unmarshal stat: %v", err)
+	}
+	if err := json.Unmarshal(ch.Writes[1], &putReq); err != nil {
+		t.Fatalf("unmarshal put: %v", err)
+	}
+	if statReq.Cmd != "stat" || statReq.Path != "/tmp/remotedir" {
+		t.Fatalf("expected stat /tmp/remotedir, got %s %q", statReq.Cmd, statReq.Path)
+	}
+	if putReq.Cmd != "put" || putReq.Path != "/tmp/remotedir/local.txt" {
+		t.Fatalf("expected put /tmp/remotedir/local.txt, got %s %q", putReq.Cmd, putReq.Path)
+	}
+}
+
+// TestScpUploadFileToNewRemoteName verifies that an upload whose remote target
+// does not exist and has no trailing slash uses the target as the remote file
+// name verbatim, like scp (scp file host:/tmp/newname copies to /tmp/newname).
+func TestScpUploadFileToNewRemoteName(t *testing.T) {
+	tmp := t.TempDir()
+	localPath := filepath.Join(tmp, "local.txt")
+	os.WriteFile(localPath, []byte("hello"), 0644)
+
+	ch := newMockChannel(
+		makeJSONDataMsg(&Response{ID: 1, OK: false, Error: "no such file"}),
+		makeJSONDataMsg(&Response{ID: 2, OK: true}),
+	)
+
+	if err := scpUpload(ch, false, localPath, "/tmp/remotefile"); err != nil {
+		t.Fatalf("scpUpload error: %v", err)
+	}
+
+	if len(ch.Writes) != 2 {
+		t.Fatalf("expected 2 requests (stat + put), got %d", len(ch.Writes))
+	}
+	var putReq Request
+	if err := json.Unmarshal(ch.Writes[1], &putReq); err != nil {
+		t.Fatalf("unmarshal put: %v", err)
+	}
+	if putReq.Cmd != "put" || putReq.Path != "/tmp/remotefile" {
+		t.Fatalf("expected put /tmp/remotefile, got %s %q", putReq.Cmd, putReq.Path)
+	}
+}
+
+// TestScpUploadDirectoryWithoutRecursive verifies that uploading a directory
+// without -r fails with a clear error.
+func TestScpUploadDirectoryWithoutRecursive(t *testing.T) {
+	tmp := t.TempDir()
+	localDir := filepath.Join(tmp, "adir")
+	os.Mkdir(localDir, 0755)
+
+	ch := newMockChannel()
+	err := scpUpload(ch, false, localDir, "/tmp/")
+	if err == nil {
+		t.Fatal("expected error for directory upload without -r")
+	}
+}
+
+// TestScpUploadRecursiveDirectoryToTrailingSlashTarget verifies that a
+// recursive directory upload to a target ending with "/" copies the directory
+// into the target under its own basename, like scp -r (scp -r ./dir host:/tmp/
+// copies to /tmp/dir).
+func TestScpUploadRecursiveDirectoryToTrailingSlashTarget(t *testing.T) {
+	tmp := t.TempDir()
+	localDir := filepath.Join(tmp, "localfolder")
+	os.MkdirAll(filepath.Join(localDir, "sub"), 0o755)
+	os.WriteFile(filepath.Join(localDir, "a.txt"), []byte("a"), 0644)
+	os.WriteFile(filepath.Join(localDir, "sub", "b.txt"), []byte("b"), 0644)
+
+	// Requests performed by uploadRecursive for a directory tree with two
+	// files:
+	//   ensureRemoteDir("/tmp/localfolder"):
+	//     stat("/tmp/localfolder") -> not found
+	//     stat("/tmp") -> is a directory
+	//     mkdir("/tmp/localfolder") -> ok
+	//   upload file "a.txt":
+	//     put("/tmp/localfolder/a.txt") -> ok
+	//   ensureRemoteDir("/tmp/localfolder/sub"):
+	//     stat("/tmp/localfolder/sub") -> not found
+	//     stat("/tmp/localfolder") -> is a directory
+	//     mkdir("/tmp/localfolder/sub") -> ok
+	//   upload file "b.txt":
+	//     put("/tmp/localfolder/sub/b.txt") -> ok
+	ch := newMockChannel(
+		makeJSONDataMsg(&Response{ID: 1, OK: false, Error: "no such file"}),
+		makeJSONDataMsg(&Response{ID: 2, OK: true, Info: &FileInfo{Name: "tmp", IsDir: true}}),
+		makeJSONDataMsg(&Response{ID: 3, OK: true}),
+		makeJSONDataMsg(&Response{ID: 4, OK: true}),
+		makeJSONDataMsg(&Response{ID: 5, OK: false, Error: "no such file"}),
+		makeJSONDataMsg(&Response{ID: 6, OK: true, Info: &FileInfo{Name: "localfolder", IsDir: true}}),
+		makeJSONDataMsg(&Response{ID: 7, OK: true}),
+		makeJSONDataMsg(&Response{ID: 8, OK: true}),
+	)
+
+	if err := scpUpload(ch, true, localDir, "/tmp/"); err != nil {
+		t.Fatalf("scpUpload -r error: %v", err)
+	}
+
+	if len(ch.Writes) != 8 {
+		t.Fatalf("expected 8 requests, got %d", len(ch.Writes))
+	}
+	var mkdirReq Request
+	if err := json.Unmarshal(ch.Writes[2], &mkdirReq); err != nil {
+		t.Fatalf("unmarshal mkdir: %v", err)
+	}
+	if mkdirReq.Cmd != "mkdir" || mkdirReq.Path != "/tmp/localfolder" {
+		t.Fatalf("expected mkdir /tmp/localfolder, got %s %q", mkdirReq.Cmd, mkdirReq.Path)
+	}
+}
+
+// TestScpDownloadToExistingLocalDir verifies that a download whose local
+// target is an existing directory copies the remote source into it under its
+// own basename, like scp (scp host:.ssh/authorized_keys . copies to
+// ./authorized_keys).
+func TestScpDownloadToExistingLocalDir(t *testing.T) {
+	tmp := t.TempDir()
+	content := []byte("hello from remote")
+
+	ch := newMockChannel(
+		makeJSONDataMsg(&Response{ID: 1, OK: true, Info: &FileInfo{Name: "remote.txt", Size: int64(len(content))}}),
+		makeJSONDataMsg(&Response{ID: 2, OK: true, Data: content}),
+		makeJSONDataMsg(&Response{ID: 3, OK: true, Data: []byte{}}),
+	)
+
+	if err := scpDownload(ch, false, "/etc/remote.txt", tmp); err != nil {
+		t.Fatalf("scpDownload error: %v", err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(tmp, "remote.txt"))
+	if err != nil {
+		t.Fatalf("read downloaded file: %v", err)
+	}
+	if string(got) != string(content) {
+		t.Fatalf("unexpected content: %q", got)
+	}
+
+	var statReq Request
+	if len(ch.Writes) != 3 {
+		t.Fatalf("expected 3 requests, got %d", len(ch.Writes))
+	}
+	if err := json.Unmarshal(ch.Writes[0], &statReq); err != nil {
+		t.Fatalf("unmarshal stat: %v", err)
+	}
+	if statReq.Cmd != "stat" || statReq.Path != "/etc/remote.txt" {
+		t.Fatalf("expected stat /etc/remote.txt, got %s %q", statReq.Cmd, statReq.Path)
+	}
+}
+
+// TestScpDownloadToTrailingSlashLocalTarget verifies that a download whose
+// local target ends with a path separator copies the remote source into that
+// directory under its own basename.
+func TestScpDownloadToTrailingSlashLocalTarget(t *testing.T) {
+	tmp := t.TempDir()
+	content := []byte("hello")
+
+	ch := newMockChannel(
+		makeJSONDataMsg(&Response{ID: 1, OK: true, Info: &FileInfo{Name: "remote.txt", Size: int64(len(content))}}),
+		makeJSONDataMsg(&Response{ID: 2, OK: true, Data: content}),
+		makeJSONDataMsg(&Response{ID: 3, OK: true, Data: []byte{}}),
+	)
+
+	target := filepath.Join(tmp, "out") + string(filepath.Separator)
+	if err := scpDownload(ch, false, "/etc/remote.txt", target); err != nil {
+		t.Fatalf("scpDownload error: %v", err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(tmp, "out", "remote.txt"))
+	if err != nil {
+		t.Fatalf("read downloaded file: %v", err)
+	}
+	if string(got) != string(content) {
+		t.Fatalf("unexpected content: %q", got)
+	}
+}
+
+// TestScpDownloadToNewLocalName verifies that a download whose local target
+// does not exist and has no trailing separator uses the target as the local
+// file name verbatim, like scp (scp host:file newname copies to ./newname).
+func TestScpDownloadToNewLocalName(t *testing.T) {
+	tmp := t.TempDir()
+	content := []byte("hello")
+
+	ch := newMockChannel(
+		makeJSONDataMsg(&Response{ID: 1, OK: true, Info: &FileInfo{Name: "remote.txt", Size: int64(len(content))}}),
+		makeJSONDataMsg(&Response{ID: 2, OK: true, Data: content}),
+		makeJSONDataMsg(&Response{ID: 3, OK: true, Data: []byte{}}),
+	)
+
+	newName := filepath.Join(tmp, "newname")
+	if err := scpDownload(ch, false, "/etc/remote.txt", newName); err != nil {
+		t.Fatalf("scpDownload error: %v", err)
+	}
+
+	got, err := os.ReadFile(newName)
+	if err != nil {
+		t.Fatalf("read downloaded file: %v", err)
+	}
+	if string(got) != string(content) {
+		t.Fatalf("unexpected content: %q", got)
+	}
+}
+
+// TestScpDownloadRecursiveToExistingLocalDir verifies that a recursive
+// directory download to an existing local directory copies the remote directory
+// into it under its own basename, like scp -r (scp -r host:/etc/nginx . copies
+// to ./nginx).
+func TestScpDownloadRecursiveToExistingLocalDir(t *testing.T) {
+	tmp := t.TempDir()
+
+	ch := newMockChannel(
+		makeJSONDataMsg(&Response{ID: 1, OK: true, Info: &FileInfo{Name: "nginx", IsDir: true}}),
+		makeJSONDataMsg(&Response{ID: 2, OK: true, Entries: []FileInfo{{Name: "nginx.conf", Size: 4, Mode: 0644}}}),
+		makeJSONDataMsg(&Response{ID: 3, OK: true, Data: []byte("conf")}),
+		makeJSONDataMsg(&Response{ID: 4, OK: true, Data: []byte{}}),
+	)
+
+	if err := scpDownload(ch, true, "/etc/nginx", tmp); err != nil {
+		t.Fatalf("scpDownload -r error: %v", err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(tmp, "nginx", "nginx.conf"))
+	if err != nil {
+		t.Fatalf("read downloaded file: %v", err)
+	}
+	if string(got) != "conf" {
+		t.Fatalf("unexpected content: %q", got)
+	}
+}
+
+// TestScpUploadMissingLocalFile verifies that uploading a non-existent local
+// path fails cleanly.
+func TestScpUploadMissingLocalFile(t *testing.T) {
+	ch := newMockChannel()
+	err := scpUpload(ch, false, "/nonexistent/file.txt", "/tmp/")
+	if err == nil {
+		t.Fatal("expected error for missing local file")
+	}
+}


### PR DESCRIPTION
Add an scp-style mode to the client that reuses the native SFTP channel and protocol, so files and directories can be copied without dropping into the interactive sftp shell. The remote path is separated from the sshoq server URL with '%', since ':' is already used for the port designation (e.g. `sshoq -scp localfile user@host:443/sshoq-server%/tmp/remotefile`). Use -r for recursive directory copies.

The scp client mirrors scp semantics: when the target is an existing directory or ends with a path separator, the source is copied into it under its own basename. Uploading a directory without -r fails with a clear error, and -sftp/-scp cannot be combined.

Adds unit tests for the argument parsing and transfer path semantics, plus end-to-end integration tests covering upload, recursive upload, download, recursive download and the SFTP-disabled error. The integration suite now also opens up the gexec build artifacts so the SFTP child process (forked with the authenticated user's credentials) can exec the server binary.