### PR TITLE
feat: support multiple simultaneous local and remote port forwardings

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,12 @@ Similarly for UDP:
 
 Warning: Reverse UDP port forwarding is not well tested and may not be working fully.
 
+### Multiple port forwardings
+
+Like OpenSSH, all forwarding flags (`-L`, `-R`, `-forward-tcp`, `-forward-udp`, `-reverse-tcp`, `-reverse-udp`) can be repeated any number of times and combined freely, including a mix of TCP and UDP and of local and reverse forwardings:
+
+`sshoq -L 8080@127.0.0.1@3000 -L 8443@127.0.0.1@443 -R 2222@127.0.0.1@22 -forward-udp 8053@127.0.0.1@5353 -reverse-udp 8888@127.0.0.1@53 user@example.com/secret-path`
+
 ## SSHOQ is still experimental
 While SSHOQ shows promise for faster session establishment, it is still at an early proof-of-concept stage. As with any new complex protocol, **expert cryptographic review over an extended timeframe is required before reasonable security conclusions can be made**.
 

--- a/client/client.go
+++ b/client/client.go
@@ -346,9 +346,6 @@ func forwardReverseUDPInBackground(ctx context.Context, channel ssh3.Channel, co
 type Client struct {
 	qconn quic.EarlyConnection
 	*ssh3.Conversation
-	// reverseTCPRemoteAddr is the destination address used to forward the
-	// server-initiated reverse TCP channels opened for -reverse-tcp.
-	reverseTCPRemoteAddr *net.TCPAddr
 }
 
 func Dial(ctx context.Context, config *client_config.Config, qconn quic.EarlyConnection,
@@ -853,11 +850,10 @@ func (c *Client) ForwardTCP(ctx context.Context, localTCPAddr *net.TCPAddr, remo
 func (c *Client) ReverseTCP(ctx context.Context, localTCPAddr *net.TCPAddr, remoteTCPAddr *net.TCPAddr) (*net.TCPAddr, error) {
 	log.Debug().Msgf("start reverse TCP forwarding from %s to %s", localTCPAddr, remoteTCPAddr)
 
-	// The server-initiated "open-request-reverse-tcp" channels are the handled by
-	// the global channel accept loop in RunSession, where the destination address
-	// is read from reverseTCPRemoteAddr (no dedicated accept loop here).
-	c.reverseTCPRemoteAddr = remoteTCPAddr
-
+	// The server-initiated "open-request-reverse-tcp,<dest>" channels are handled
+	// by the global channel accept loop in RunSession, which reads the destination
+	// address from the channel type (so multiple reverse TCP forwardings can
+	// coexist).
 	forwardingChannel, err := c.RequestTCPReverseChannel(30000, 10, localTCPAddr, remoteTCPAddr)
 	if err != nil {
 		log.Error().Msgf("could open new TCP reverse forwarding channel: %s", err)
@@ -901,6 +897,22 @@ func parseAddrsFromChannelType(typ string) (*net.UDPAddr, *net.UDPAddr, error) {
 	}
 
 	return localUDPAddr, remoteUDPAddr, nil
+}
+
+// parseReverseTCPDestFromChannelType extracts the destination address (the
+// socket at reach of the SSH3 client) from an "open-request-reverse-tcp,<dest>"
+// channel type.
+func parseReverseTCPDestFromChannelType(typ string) (*net.TCPAddr, error) {
+	parts := strings.SplitN(typ, ",", 2)
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("bad format (want: open-request-reverse-tcp,<remote>): %q", typ)
+	}
+	destStr := strings.TrimSpace(parts[1])
+	destAddr, err := net.ResolveTCPAddr("tcp", destStr)
+	if err != nil {
+		return nil, fmt.Errorf("parse reverse TCP destination addr %q: %w", destStr, err)
+	}
+	return destAddr, nil
 }
 
 func parseUDPRequestReverseHeader(channelID uint64, buf util.Reader) (*net.UDPAddr, *net.UDPAddr, error) {
@@ -1028,19 +1040,21 @@ func (c *Client) RunSession(tty *os.File, forwardSSHAgent bool, forcePTYAlloc bo
 				}
 			}
 
-			switch channel.ChannelType() {
-			case "open-request-reverse-tcp":
+			switch {
+			case strings.HasPrefix(typ, "open-request-reverse-tcp"):
 				// reverse TCP channels are opened by the server for -reverse-tcp;
-				// the destination address is set by ReverseTCP.
-				if c.reverseTCPRemoteAddr == nil {
-					log.Error().Msgf("received a reverse TCP forwarding channel but no reverse TCP forwarding was requested")
+				// the destination address is encoded in the channel type so that
+				// multiple simultaneous reverse TCP forwardings can be told apart.
+				reverseTCPDestAddr, err := parseReverseTCPDestFromChannelType(channel.ChannelType())
+				if err != nil {
+					log.Error().Msgf("received an invalid reverse TCP forwarding channel: %s", err)
 					channel.Close()
 					continue
 				}
-				log.Debug().Msgf("start reverse TCP forwarding to %s", c.reverseTCPRemoteAddr)
-				conn, err := net.DialTCP("tcp", nil, c.reverseTCPRemoteAddr)
+				log.Debug().Msgf("start reverse TCP forwarding to %s", reverseTCPDestAddr)
+				conn, err := net.DialTCP("tcp", nil, reverseTCPDestAddr)
 				if err != nil {
-					log.Error().Msgf("could not dial reverse TCP destination %s: %s", c.reverseTCPRemoteAddr, err)
+					log.Error().Msgf("could not dial reverse TCP destination %s: %s", reverseTCPDestAddr, err)
 					channel.Close()
 					continue
 				}

--- a/client/client.go
+++ b/client/client.go
@@ -363,8 +363,8 @@ func Dial(ctx context.Context, config *client_config.Config, qconn quic.EarlyCon
 
 	var qconf quic.Config
 
-	qconf.MaxIncomingUniStreams = 10000
-	qconf.MaxIncomingStreams = 10000
+	qconf.MaxIncomingUniStreams = 100000
+	qconf.MaxIncomingStreams = 100000
 	qconf.Allow0RTT = false
 	qconf.EnableDatagrams = true
 	qconf.KeepAlivePeriod = 1 * time.Second

--- a/cmd/sshoq-server.go
+++ b/cmd/sshoq-server.go
@@ -1231,8 +1231,8 @@ func ServerMain() int {
 		Allow0RTT:             false,
 		KeepAlivePeriod:       1 * time.Second,
 		EnableDatagrams:       true,
-		MaxIncomingStreams:    10000, // client-initiated bidi streams allowed
-		MaxIncomingUniStreams: 10000, // client-initiated uni streams allowed
+		MaxIncomingStreams:    100000, // client-initiated bidi streams allowed
+		MaxIncomingUniStreams: 100000, // client-initiated uni streams allowed
 	}
 
 	var err error

--- a/cmd/sshoq.go
+++ b/cmd/sshoq.go
@@ -97,8 +97,8 @@ func setupQUICConnection(ctx context.Context, skipHostVerification bool, keylog 
 
 	var qconf quic.Config
 
-	qconf.MaxIncomingUniStreams = 10000
-	qconf.MaxIncomingStreams = 10000
+	qconf.MaxIncomingUniStreams = 100000
+	qconf.MaxIncomingStreams = 100000
 	qconf.Allow0RTT = false
 	qconf.EnableDatagrams = true
 	qconf.KeepAlivePeriod = 1 * time.Second

--- a/cmd/sshoq.go
+++ b/cmd/sshoq.go
@@ -253,6 +253,139 @@ func parseAddrPort(addrPort string) (localIP net.IP, localPort int, remoteIP net
 	return localIP, localPort, remoteIP, remotePort, err
 }
 
+// stringSliceFlag is a flag.Value that accumulates every occurrence of the flag,
+// allowing repeated flags such as multiple -L or -R (like OpenSSH).
+type stringSliceFlag []string
+
+func (s *stringSliceFlag) String() string {
+	return strings.Join(*s, ",")
+}
+
+func (s *stringSliceFlag) Set(value string) error {
+	*s = append(*s, value)
+	return nil
+}
+
+// localIPForForwarding picks the local bind IP according to the remote address
+// family, defaulting to the loopback of the same family, like OpenSSH does.
+func localIPForForwarding(localIP net.IP, remoteIP net.IP) net.IP {
+	if remoteIP.To4() != nil {
+		if localIP.To4() != nil {
+			return localIP.To4()
+		}
+		return net.IPv4(127, 0, 0, 1)
+	}
+	if remoteIP.To16() != nil {
+		if localIP.To16() != nil {
+			return localIP.To16()
+		}
+		return net.IPv6loopback
+	}
+	return nil
+}
+
+// parseTCPForwarding parses a single forwarding spec "[bindip:]localport@remoteip@remoteport"
+// into a local/remote TCP address pair.
+func parseTCPForwarding(forwardSpec string) (local *net.TCPAddr, remote *net.TCPAddr, err error) {
+	localIP, localPort, remoteIP, remotePort, err := parseAddrPort(forwardSpec)
+	if err != nil {
+		return nil, nil, err
+	}
+	bindIP := localIPForForwarding(localIP, remoteIP)
+	if bindIP == nil {
+		return nil, nil, fmt.Errorf("unrecognized remote IP length %d", len(remoteIP))
+	}
+	return &net.TCPAddr{IP: bindIP, Port: localPort}, &net.TCPAddr{IP: remoteIP, Port: remotePort}, nil
+}
+
+// parseUDPForwarding parses a single forwarding spec "[bindip:]localport@remoteip@remoteport"
+// into a local/remote UDP address pair.
+func parseUDPForwarding(forwardSpec string) (local *net.UDPAddr, remote *net.UDPAddr, err error) {
+	localIP, localPort, remoteIP, remotePort, err := parseAddrPort(forwardSpec)
+	if err != nil {
+		return nil, nil, err
+	}
+	bindIP := localIPForForwarding(localIP, remoteIP)
+	if bindIP == nil {
+		return nil, nil, fmt.Errorf("unrecognized remote IP length %d", len(remoteIP))
+	}
+	return &net.UDPAddr{IP: bindIP, Port: localPort}, &net.UDPAddr{IP: remoteIP, Port: remotePort}, nil
+}
+
+// splitForwardingSpecs expands a single flag value into individual forwarding specs.
+// Comma separated values (previously supported by -forward-udp/-reverse-udp) are
+// kept for backwards compatibility, and repeated flags are all handled here too.
+func splitForwardingSpecs(groups []string) []string {
+	var specs []string
+	for _, group := range groups {
+		for _, spec := range strings.Split(group, ",") {
+			spec = strings.TrimSpace(spec)
+			if spec == "" {
+				continue
+			}
+			specs = append(specs, spec)
+		}
+	}
+	return specs
+}
+
+// setupForwardings starts every local and remote port forwarding that was
+// requested on the command line. Multiple -L, -R, -forward-tcp, -forward-udp,
+// -reverse-tcp and -reverse-udp flags can be freely combined, in any order, and
+// with a mix of TCP and UDP. It returns the updated multicast UDP connection
+// (if any was created) that subsequent forwardings should reuse.
+func setupForwardings(ctx context.Context, c *client.Client, forwardTCP, reverseTCP, forwardUDP, reverseUDP []string, fwUDPmulticonn *net.UDPConn) (*net.UDPConn, error) {
+	// Local TCP forwardings (-L / -forward-tcp): a local port is forwarded to a remote port.
+	for _, spec := range splitForwardingSpecs(forwardTCP) {
+		local, remote, err := parseTCPForwarding(spec)
+		if err != nil {
+			return fwUDPmulticonn, fmt.Errorf("TCP forwarding parsing error for %q: %s", spec, err)
+		}
+		if _, err := c.ForwardTCP(ctx, local, remote); err != nil {
+			return fwUDPmulticonn, fmt.Errorf("could not forward TCP %s -> %s: %s", local, remote, err)
+		}
+	}
+
+	// Reverse TCP forwardings (-R / -reverse-tcp): a remote port is forwarded to a local port.
+	for _, spec := range splitForwardingSpecs(reverseTCP) {
+		local, remote, err := parseTCPForwarding(spec)
+		if err != nil {
+			return fwUDPmulticonn, fmt.Errorf("TCP reverse parsing error for %q: %s", spec, err)
+		}
+		if _, err := c.ReverseTCP(ctx, local, remote); err != nil {
+			return fwUDPmulticonn, fmt.Errorf("could not reverse TCP %s -> %s: %s", local, remote, err)
+		}
+	}
+
+	// Local UDP forwardings (-forward-udp): a local port is forwarded to a remote port.
+	for _, spec := range splitForwardingSpecs(forwardUDP) {
+		local, remote, err := parseUDPForwarding(spec)
+		if err != nil {
+			return fwUDPmulticonn, fmt.Errorf("UDP forwarding parsing error for %q: %s", spec, err)
+		}
+		_, conn, err := c.ForwardUDP(ctx, local, remote, fwUDPmulticonn)
+		if err != nil {
+			return fwUDPmulticonn, fmt.Errorf("could not forward UDP %s -> %s: %s", local, remote, err)
+		}
+		if local.IP.IsMulticast() {
+			fwUDPmulticonn = conn
+		}
+	}
+
+	// Reverse UDP forwardings (-reverse-udp): a remote port is forwarded to a local port.
+	for _, spec := range splitForwardingSpecs(reverseUDP) {
+		local, remote, err := parseUDPForwarding(spec)
+		if err != nil {
+			return fwUDPmulticonn, fmt.Errorf("UDP reverse parsing error for %q: %s", spec, err)
+		}
+		if _, err := c.ReverseUDP(ctx, local, remote); err != nil {
+			return fwUDPmulticonn, fmt.Errorf("could not reverse UDP %s -> %s: %s", local, remote, err)
+		}
+	}
+
+	return fwUDPmulticonn, nil
+}
+
 func getConfigOptions(hostUrl *url.URL, sshConfig *ssh_config.Config, optionParsers map[client_config.OptionName]client_config.OptionParser) (*client_config.Config, error) {
 	urlHostname, urlPort := hostUrl.Hostname(), hostUrl.Port()
 
@@ -484,12 +617,16 @@ func ClientMain() int {
 	noPKCE := flag.Bool("no-pkce", false, "if set perform PKCE challenge-response with oidc")
 	forcePTYAlloc := flag.Bool("force-pty", false, "if set, forces PTY allocation before command execution. Useful for interactive programs.")
 	forwardSSHAgent := flag.Bool("forward-agent", false, "if set, forwards ssh agent to be used with sshv2 connections on the remote host")
-	forwardTCP := flag.String("forward-tcp", "", "forward a remote TCP port to a local port. Syntax same as SSH2 but with @ instead of : (e.g. 8080@::1@80 or 8080@192.168.1.1@80)")
-	forwardUDP := flag.String("forward-udp", "", "forward a remote UDP port to a local port. Syntax same as SSH2 but with @ instead of : (e.g. 5353@::1@53)")
-	reverseTCP := flag.String("reverse-tcp", "", "reverse forward a local TCP port to a remote port. Syntax same as SSH2 but with @ instead of : (e.g. 80@127.0.0.1@8080)")
-	reverseUDP := flag.String("reverse-udp", "", "reverse forward a local UDP port to a remote port. Syntax same as SSH2 but with @ instead of : (e.g. 53@127.0.0.1@5353)")
-	flag.StringVar(forwardTCP, "L", *forwardTCP, "alias for -forward-tcp")
-	flag.StringVar(reverseTCP, "R", *reverseTCP, "alias for -reverse-tcp")
+	var forwardTCP stringSliceFlag
+	var forwardUDP stringSliceFlag
+	var reverseTCP stringSliceFlag
+	var reverseUDP stringSliceFlag
+	flag.Var(&forwardTCP, "forward-tcp", "forward a remote TCP port to a local port. Syntax same as SSH2 but with @ instead of : (e.g. 8080@::1@80 or 8080@192.168.1.1@80). May be specified multiple times.")
+	flag.Var(&forwardUDP, "forward-udp", "forward a remote UDP port to a local port. Syntax same as SSH2 but with @ instead of : (e.g. 5353@::1@53). May be specified multiple times.")
+	flag.Var(&reverseTCP, "reverse-tcp", "reverse forward a local TCP port to a remote port. Syntax same as SSH2 but with @ instead of : (e.g. 80@127.0.0.1@8080). May be specified multiple times.")
+	flag.Var(&reverseUDP, "reverse-udp", "reverse forward a local UDP port to a remote port. Syntax same as SSH2 but with @ instead of : (e.g. 53@127.0.0.1@5353). May be specified multiple times.")
+	flag.Var(&forwardTCP, "L", "alias for -forward-tcp (may be specified multiple times)")
+	flag.Var(&reverseTCP, "R", "alias for -reverse-tcp (may be specified multiple times)")
 	proxyJump := flag.String("proxy-jump", "", "if set, performs a proxy jump using the specified remote host as proxy (requires server with version >= 0.1.5)")
 	sftpMode := flag.Bool("sftp", false, "if set, start an interactive SFTP session")
 	scpMode := flag.Bool("scp", false, "if set, copy files to or from the remote host non-interactively, like scp")
@@ -593,91 +730,8 @@ func ClientMain() int {
 		urlFromParam = fmt.Sprintf("https://%s", urlFromParam)
 	}
 
-	var localUDPAddr *net.UDPAddr = nil
-	var remoteUDPAddr *net.UDPAddr = nil
-	var localTCPAddr *net.TCPAddr = nil
-	var remoteTCPAddr *net.TCPAddr = nil
-
 	var fwUDPmulticonn *net.UDPConn
 	fwUDPmulticonn = nil
-
-	if *forwardTCP != "" {
-		localIP, localPort, remoteIP, remotePort, err := parseAddrPort(*forwardTCP)
-		if err != nil {
-			log.Error().Msgf("UDP forwarding parsing error %s", err)
-		}
-		remoteTCPAddr = &net.TCPAddr{
-			IP:   remoteIP,
-			Port: remotePort,
-		}
-		if remoteIP.To4() != nil {
-			if localIP.To4() != nil {
-				localTCPAddr = &net.TCPAddr{
-					IP:   localIP.To4(),
-					Port: localPort,
-				}
-			} else {
-				localTCPAddr = &net.TCPAddr{
-					IP:   net.IPv4(127, 0, 0, 1),
-					Port: localPort,
-				}
-			}
-		} else if remoteIP.To16() != nil {
-			if localIP.To16() != nil {
-				localTCPAddr = &net.TCPAddr{
-					IP:   localIP.To16(),
-					Port: localPort,
-				}
-			} else {
-				localTCPAddr = &net.TCPAddr{
-					IP:   net.IPv6loopback,
-					Port: localPort,
-				}
-			}
-		} else {
-			log.Error().Msgf("Unrecognized IP length %d", len(remoteIP))
-			return -1
-		}
-	}
-
-	if *reverseTCP != "" {
-		localIP, localPort, remoteIP, remotePort, err := parseAddrPort(*reverseTCP)
-		if err != nil {
-			log.Error().Msgf("TCP reverse parsing error %s", err)
-		}
-		remoteTCPAddr = &net.TCPAddr{
-			IP:   remoteIP,
-			Port: remotePort,
-		}
-		if remoteIP.To4() != nil {
-			if localIP.To4() != nil {
-				localTCPAddr = &net.TCPAddr{
-					IP:   localIP.To4(),
-					Port: localPort,
-				}
-			} else {
-				localTCPAddr = &net.TCPAddr{
-					IP:   net.IPv4(127, 0, 0, 1),
-					Port: localPort,
-				}
-			}
-		} else if remoteIP.To16() != nil {
-			if localIP.To16() != nil {
-				localTCPAddr = &net.TCPAddr{
-					IP:   localIP.To16(),
-					Port: localPort,
-				}
-			} else {
-				localTCPAddr = &net.TCPAddr{
-					IP:   net.IPv6loopback,
-					Port: localPort,
-				}
-			}
-		} else {
-			log.Error().Msgf("Unrecognized IP length %d", len(remoteIP))
-			return -1
-		}
-	}
 
 	var sshConfig *ssh_config.Config
 	var configBytes []byte
@@ -890,144 +944,13 @@ func ClientMain() int {
 		log.Error().Msgf("could not dial %s: %s", options.CanonicalHostFormat(), err)
 		return -1
 	}
-	if *forwardTCP != "" && localTCPAddr != nil && remoteTCPAddr != nil {
-		_, err := c.ForwardTCP(ctx, localTCPAddr, remoteTCPAddr)
-		if err != nil {
-			log.Error().Msgf("could not forward UDP: %s", err)
-			return -1
-		}
-	}
-	if *reverseTCP != "" && localTCPAddr != nil && remoteTCPAddr != nil {
-		_, err := c.ReverseTCP(ctx, localTCPAddr, remoteTCPAddr)
-		if err != nil {
-			log.Error().Msgf("could not reverse TCP: %s", err)
-			return -1
-		}
-	}
-
-	if *reverseUDP != "" {
-		v := strings.TrimSpace(*reverseUDP)
-		if v == "" {
-			return -1
-		}
-		parts := strings.Split(v, ",")
-		for _, p := range parts {
-			p = strings.TrimSpace(p)
-			if p == "" {
-				continue
-			}
-			log.Printf("reverseUDP p: %s", p)
-			localIP, localPort, remoteIP, remotePort, err := parseAddrPort(p)
-			if err != nil {
-				log.Error().Msgf("UDP reverse parsing error %s", err)
-			}
-			remoteUDPAddr = &net.UDPAddr{
-				IP:   remoteIP,
-				Port: remotePort,
-			}
-			if remoteIP.To4() != nil {
-				if localIP.To4() != nil {
-					localUDPAddr = &net.UDPAddr{
-						IP:   localIP.To4(),
-						Port: localPort,
-					}
-				} else {
-					localUDPAddr = &net.UDPAddr{
-						IP:   net.IPv4(127, 0, 0, 1),
-						Port: localPort,
-					}
-				}
-			} else if remoteIP.To16() != nil {
-				if localIP.To16() != nil {
-					localUDPAddr = &net.UDPAddr{
-						IP:   localIP.To16(),
-						Port: localPort,
-					}
-				} else {
-					localUDPAddr = &net.UDPAddr{
-						IP:   net.IPv6loopback,
-						Port: localPort,
-					}
-				}
-
-			} else {
-				log.Error().Msgf("Unrecognized IP length %d", len(remoteIP))
-				return -1
-			}
-
-			if *reverseUDP != "" && localUDPAddr != nil && remoteUDPAddr != nil {
-				_, err := c.ReverseUDP(ctx, localUDPAddr, remoteUDPAddr)
-				if err != nil {
-					log.Error().Msgf("could not reverse UDP: %s", err)
-					return -1
-				}
-			}
-
-		}
-	}
-
-	if *forwardUDP != "" {
-		v := strings.TrimSpace(*forwardUDP)
-		if v == "" {
-			return -1
-		}
-		parts := strings.Split(v, ",")
-		for _, p := range parts {
-			p = strings.TrimSpace(p)
-			if p == "" {
-				continue
-			}
-			log.Printf("forwardUDP p: %s", p)
-			localIP, localPort, remoteIP, remotePort, err := parseAddrPort(p)
-			if err != nil {
-				log.Error().Msgf("UDP forwarding parsing error %s", err)
-			}
-			remoteUDPAddr = &net.UDPAddr{
-				IP:   remoteIP,
-				Port: remotePort,
-			}
-			if remoteIP.To4() != nil {
-				if localIP.To4() != nil {
-					localUDPAddr = &net.UDPAddr{
-						IP:   localIP.To4(),
-						Port: localPort,
-					}
-				} else {
-					localUDPAddr = &net.UDPAddr{
-						IP:   net.IPv4(127, 0, 0, 1),
-						Port: localPort,
-					}
-				}
-			} else if remoteIP.To16() != nil {
-				if localIP.To16() != nil {
-					localUDPAddr = &net.UDPAddr{
-						IP:   localIP.To16(),
-						Port: localPort,
-					}
-				} else {
-					localUDPAddr = &net.UDPAddr{
-						IP:   net.IPv6loopback,
-						Port: localPort,
-					}
-				}
-			} else {
-				log.Error().Msgf("Unrecognized IP length %d", len(remoteIP))
-				return -1
-			}
-
-			if *forwardUDP != "" && localUDPAddr != nil && remoteUDPAddr != nil {
-				_, conn, err := c.ForwardUDP(ctx, localUDPAddr, remoteUDPAddr, fwUDPmulticonn)
-				if err != nil {
-					log.Error().Msgf("could not forward UDP: %s", err)
-					return -1
-				}
-				if localUDPAddr.IP.IsMulticast() {
-					fwUDPmulticonn = conn
-				}
-			}
-
-		}
-
+	// Set up all requested local and remote port forwardings. Multiple -L, -R,
+	// -forward-tcp, -forward-udp, -reverse-tcp and -reverse-udp flags can now
+	// be combined freely, including a mix of TCP and UDP.
+	fwUDPmulticonn, err = setupForwardings(ctx, c, forwardTCP, reverseTCP, forwardUDP, reverseUDP, fwUDPmulticonn)
+	if err != nil {
+		log.Error().Msgf("%s", err)
+		return -1
 	}
 
 	if *sftpMode {

--- a/conversation.go
+++ b/conversation.go
@@ -342,9 +342,11 @@ func (c *Conversation) OpenTCPReverseForwardingChannel(maxPacketSize uint64, dat
 	if err != nil {
 		return nil, err
 	}
-	//missing additional bites!! if occurs more than a single reverse forwarding, there will be no way to tell appart which request is for which destination
-
-	channel := NewChannel(uint64(c.controlStream.StreamID()), c.conversationID, uint64(str.StreamID()), "open-request-reverse-tcp", maxPacketSize, &StreamByteReader{str}, str, nil, c.channelsManager, true, true, false, datagramsQueueSize, nil)
+	// The destination address (the socket at reach of the SSH3 client that the
+	// data must be forwarded to) is encoded in the channel type, like it is for
+	// UDP reverse forwardings, so that multiple simultaneous reverse TCP
+	// forwardings can be told apart by the client.
+	channel := NewChannel(uint64(c.controlStream.StreamID()), c.conversationID, uint64(str.StreamID()), "open-request-reverse-tcp,"+remoteAddr.String(), maxPacketSize, &StreamByteReader{str}, str, nil, c.channelsManager, true, true, false, datagramsQueueSize, nil)
 	channel.maybeSendHeader()
 	c.channelsManager.addChannel(channel)
 	return &TCPOpenReverseForwardingChannelImpl{Channel: channel, RemoteAddr: remoteAddr}, nil

--- a/integration_tests/sshoq_test.go
+++ b/integration_tests/sshoq_test.go
@@ -461,6 +461,169 @@ var _ = Describe("Testing the sshoq cli", func() {
 						testTCPPortForwarding(8082, false, &net.TCPAddr{IP: net.ParseIP("::1"), Port: 9090}, "hello from client", "hello from server", "-forward-tcp")
 						testTCPPortForwarding(8093, false, &net.TCPAddr{IP: net.ParseIP("::1"), Port: 9090}, "hello from client", "hello from server", "-reverse-tcp")
 					})
+
+					// tcpForwardingSpec describes one TCP port forwarding used by the
+					// multiple-forwarding tests: either a local forward (-L) or a
+					// reverse forward (-R).
+					type tcpForwardingSpec struct {
+						forwardingType    string // "-forward-tcp" or "-reverse-tcp"
+						localPort         uint16 // bound on the client (-L) or on the server (-R)
+						remotePort        uint16 // destination at server's reach (-L) or at client's reach (-R)
+						messageFromClient string
+						messageFromServer string
+					}
+
+					// testMultipleTCPPortForwardings starts a single client that sets up
+					// several TCP port forwardings at once (multiple -forward-tcp/-L
+					// and/or -reverse-tcp/-R flags) and checks that every forwarding
+					// works concurrently.
+					testMultipleTCPPortForwardings := func(forwardings []tcpForwardingSpec) {
+						const bindIP = "127.0.0.1"
+
+						serverStarted := make(chan struct{}, len(forwardings))
+						done := make(chan struct{}, len(forwardings))
+						errCh := make(chan error, len(forwardings))
+
+						// Start one target TCP server per forwarding
+						for _, fwd := range forwardings {
+							fwd := fwd
+							go func() {
+								defer GinkgoRecover()
+								listener, err := net.ListenTCP("tcp", &net.TCPAddr{IP: net.ParseIP(bindIP), Port: int(fwd.remotePort)})
+								if err != nil {
+									errCh <- err
+									return
+								}
+								defer listener.Close()
+								serverStarted <- struct{}{}
+
+								conn, err := listener.Accept()
+								if err != nil {
+									errCh <- err
+									return
+								}
+								defer conn.Close()
+
+								// Read the message coming from the client through the tunnel
+								buffer := make([]byte, len(fwd.messageFromClient))
+								if _, err := io.ReadFull(conn, buffer); err != nil {
+									errCh <- err
+									return
+								}
+								if string(buffer) != fwd.messageFromClient {
+									errCh <- fmt.Errorf("target %d: got %q, want %q", fwd.remotePort, buffer, fwd.messageFromClient)
+									return
+								}
+
+								// Send a message back through the tunnel
+								if _, err := conn.Write([]byte(fwd.messageFromServer)); err != nil {
+									errCh <- err
+									return
+								}
+								conn.(*net.TCPConn).CloseWrite()
+
+								// The client must close its side once the exchange is over
+								n, err := conn.Read(buffer)
+								if err != io.EOF || n != 0 {
+									errCh <- fmt.Errorf("target %d: expected EOF, got n=%d err=%v", fwd.remotePort, n, err)
+									return
+								}
+								done <- struct{}{}
+							}()
+						}
+
+						// Wait for all the target servers to be ready
+						for range forwardings {
+							Eventually(serverStarted).Should(Receive())
+						}
+
+						// Start the client with every forwarding declared at once
+						additionalArgs := []string{}
+						for _, fwd := range forwardings {
+							additionalArgs = append(additionalArgs, fwd.forwardingType, fmt.Sprintf("%d@%s@%d", fwd.localPort, bindIP, fwd.remotePort))
+						}
+						clientArgs := getClientArgs(rsaPrivKeyPath, additionalArgs...)
+						command := exec.Command(ssh3Path, clientArgs...)
+						session, err := Start(command, GinkgoWriter, GinkgoWriter)
+						Expect(err).ToNot(HaveOccurred())
+						defer session.Terminate()
+
+						// Connect to every forwarded port and exchange messages through each tunnel
+						for _, fwd := range forwardings {
+							func() {
+								localAddr := fmt.Sprintf("%s:%d", bindIP, fwd.localPort)
+								var conn net.Conn
+								// connection refused might happen between the time the process
+								// starts and actually listens the socket
+								Eventually(func() error {
+									var err error
+									conn, err = net.Dial("tcp", localAddr)
+									return err
+								}).ShouldNot(HaveOccurred())
+								defer conn.Close()
+
+								n, err := conn.Write([]byte(fwd.messageFromClient))
+								Expect(err).ToNot(HaveOccurred())
+								Expect(n).To(Equal(len(fwd.messageFromClient)))
+								conn.(*net.TCPConn).CloseWrite()
+
+								buffer := make([]byte, len(fwd.messageFromServer))
+								conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+								total := 0
+								for total < len(buffer) {
+									n, err = conn.Read(buffer[total:])
+									total += n
+									if err != nil {
+										Expect(err).To(SatisfyAny(BeNil(), Equal(io.EOF)))
+										break
+									}
+								}
+								Expect(total).To(Equal(len(fwd.messageFromServer)))
+								Expect(string(buffer)).To(Equal(fwd.messageFromServer))
+
+								// The tunnel must be closed on both sides: no extra byte
+								n, err = conn.Read(buffer)
+								Expect(n).To(Equal(0))
+								Expect(err).To(Equal(io.EOF))
+							}()
+						}
+
+						// Every target server must have received its message
+						remaining := len(forwardings)
+						for remaining > 0 {
+							select {
+							case err := <-errCh:
+								Fail(fmt.Sprintf("target server error: %s", err))
+							case <-done:
+								remaining--
+							case <-time.After(10 * time.Second):
+								Fail("timed out waiting for target servers to finish")
+							}
+						}
+					}
+
+					It("works with multiple local port forwardings (-L)", func() {
+						testMultipleTCPPortForwardings([]tcpForwardingSpec{
+							{"-forward-tcp", 8100, 9100, "hello to remote 1", "hello from remote 1"},
+							{"-forward-tcp", 8101, 9101, "hello to remote 2", "hello from remote 2"},
+						})
+					})
+
+					It("works with multiple remote port forwardings (-R)", func() {
+						testMultipleTCPPortForwardings([]tcpForwardingSpec{
+							{"-reverse-tcp", 8200, 9200, "hello to local 1", "hello from local 1"},
+							{"-reverse-tcp", 8201, 9201, "hello to local 2", "hello from local 2"},
+						})
+					})
+
+					It("works with a mix of local and remote port forwardings", func() {
+						testMultipleTCPPortForwardings([]tcpForwardingSpec{
+							{"-forward-tcp", 8300, 9300, "hello to remote 1", "hello from remote 1"},
+							{"-reverse-tcp", 8301, 9301, "hello to local 1", "hello from local 1"},
+							{"-forward-tcp", 8302, 9302, "hello to remote 2", "hello from remote 2"},
+							{"-reverse-tcp", 8303, 9303, "hello to local 2", "hello from local 2"},
+						})
+					})
 				})
 			})
 


### PR DESCRIPTION
Allow -L/-forward-tcp, -R/-reverse-tcp, -forward-udp and -reverse-udp to be repeated any number of times and freely combined (TCP and UDP, local and reverse), like OpenSSH.

- Replace single-value forwarding flags with a repeatable stringSliceFlag.
- Add setupForwardings() to start every requested forwarding after dialing.
- Encode the destination address in the server-initiated reverse TCP channel type (open-request-reverse-tcp,<dest>) so the client can tell multiple simultaneous reverse TCP forwardings apart, mirroring how UDP reverse forwardings already encode their addresses.
- Update the client accept loop to parse the destination from the channel type instead of a single reverseTCPRemoteAddr field.
- Document multiple forwardings in the README.