### PR TITLE
fix: correct the port forwarding syntax error message

### DIFF
--- a/cmd/sshoq.go
+++ b/cmd/sshoq.go
@@ -212,8 +212,8 @@ func setupQUICConnection(ctx context.Context, skipHostVerification bool, keylog 
 func parseAddrPort(addrPort string) (localIP net.IP, localPort int, remoteIP net.IP, remotePort int, err error) {
 	array := strings.Split(addrPort, "@")
 
-	if len(array) < 3 {
-		return nil, 0, nil, 0, fmt.Errorf("Syntax incorrect for port forwarding. Use [bindip]:port:ip:port (bindip is optional), same as openssh")
+	if len(array) < 3 || len(array) > 4 {
+		return nil, 0, nil, 0, fmt.Errorf("Syntax incorrect for port forwarding. Use [bindip:]localport@remoteip@remoteport (bindip is optional), same as openssh but with @ instead of :")
 	}
 	localIPStr := "127.0.0.1" // always default to localhost if not specified
 	remoteIPStr := "127.0.0.1"

--- a/cmd/sshoq_test.go
+++ b/cmd/sshoq_test.go
@@ -1,9 +1,11 @@
 package cmd
 
 import (
+	"net"
 	"net/url"
 	"os"
 	"path"
+	"strings"
 	"testing"
 
 	"github.com/h4sh5/sshoq"
@@ -274,4 +276,87 @@ func TestParseScpArgsRemotePathContainsPercent(t *testing.T) {
 	if urlParam != "user@remote:443/sshoq-server" {
 		t.Errorf("expected urlParam user@remote:443/sshoq-server, got %s", urlParam)
 	}
+}
+
+func TestParseAddrPort(t *testing.T) {
+	const syntaxError = "Use [bindip:]localport@remoteip@remoteport (bindip is optional), same as openssh but with @ instead of :"
+
+	t.Run("valid 3-part syntax without bind IP", func(t *testing.T) {
+		localIP, localPort, remoteIP, remotePort, err := parseAddrPort("8080@127.0.0.1@9090")
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+		if !localIP.Equal(net.ParseIP("127.0.0.1")) {
+			t.Errorf("expected local IP 127.0.0.1, got %s", localIP)
+		}
+		if localPort != 8080 {
+			t.Errorf("expected local port 8080, got %d", localPort)
+		}
+		if !remoteIP.Equal(net.ParseIP("127.0.0.1")) {
+			t.Errorf("expected remote IP 127.0.0.1, got %s", remoteIP)
+		}
+		if remotePort != 9090 {
+			t.Errorf("expected remote port 9090, got %d", remotePort)
+		}
+	})
+
+	t.Run("valid 4-part syntax with bind IP", func(t *testing.T) {
+		localIP, localPort, remoteIP, remotePort, err := parseAddrPort("0.0.0.0@8080@::1@9090")
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+		if !localIP.Equal(net.ParseIP("0.0.0.0")) {
+			t.Errorf("expected local IP 0.0.0.0, got %s", localIP)
+		}
+		if localPort != 8080 {
+			t.Errorf("expected local port 8080, got %d", localPort)
+		}
+		if !remoteIP.Equal(net.ParseIP("::1")) {
+			t.Errorf("expected remote IP ::1, got %s", remoteIP)
+		}
+		if remotePort != 9090 {
+			t.Errorf("expected remote port 9090, got %d", remotePort)
+		}
+	})
+
+	t.Run("rejects too few parts with syntax error", func(t *testing.T) {
+		_, _, _, _, err := parseAddrPort("8080@127.0.0.1")
+		if err == nil {
+			t.Fatal("expected an error, got nil")
+		}
+		if !strings.Contains(err.Error(), syntaxError) {
+			t.Errorf("error message should mention the correct @ syntax, got: %s", err)
+		}
+	})
+
+	t.Run("rejects too many parts with syntax error", func(t *testing.T) {
+		_, _, _, _, err := parseAddrPort("0.0.0.0@8080@127.0.0.1@9090@extra")
+		if err == nil {
+			t.Fatal("expected an error, got nil")
+		}
+		if !strings.Contains(err.Error(), syntaxError) {
+			t.Errorf("error message should mention the correct @ syntax, got: %s", err)
+		}
+	})
+
+	t.Run("rejects invalid IP", func(t *testing.T) {
+		_, _, _, _, err := parseAddrPort("8080@not-an-ip@9090")
+		if err == nil {
+			t.Fatal("expected an error, got nil")
+		}
+	})
+
+	t.Run("rejects invalid port", func(t *testing.T) {
+		_, _, _, _, err := parseAddrPort("notaport@127.0.0.1@9090")
+		if err == nil {
+			t.Fatal("expected an error, got nil")
+		}
+	})
+
+	t.Run("rejects port too large", func(t *testing.T) {
+		_, _, _, _, err := parseAddrPort("70000@127.0.0.1@9090")
+		if err == nil {
+			t.Fatal("expected an error, got nil")
+		}
+	})
 }


### PR DESCRIPTION
The forwarding syntax parser splits on '@', so the error message wrongly telling users to use [bindip]:port:ip:port was misleading. Fix it to describe the actual format: [bindip:]localport@remoteip@remoteport, and reject inputs with more than 4 parts (previously they silently fell through with default values instead of erroring).

Add unit tests covering the valid 3-part and 4-part syntaxes and the invalid (too few, too many, bad IP, bad port, out-of-range port) cases.