### PR TITLE
feat: add tab completion for file paths in the SFTP client

### DIFF
--- a/sftp/client.go
+++ b/sftp/client.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode"
 
 	ssh3 "github.com/h4sh5/sshoq"
 	"github.com/h4sh5/sshoq/client"
@@ -33,6 +34,9 @@ func RunInteractiveClient(c *client.Client) error {
 		return err
 	}
 	defer input.close()
+	if input.editor != nil {
+		input.editor.completer = newCompleter(channel, &localDir, &remoteDir)
+	}
 
 	for {
 		line, err := input.readLine("sftp> ")
@@ -221,6 +225,153 @@ func RunInteractiveClient(c *client.Client) error {
 	}
 
 	return nil
+}
+
+// newCompleter builds the tab-completion callback for the interactive SFTP
+// shell. It completes remote paths (resolved against *remoteDir, listed over
+// the sftp channel) for commands that operate on the remote filesystem, and
+// local paths (resolved against *localDir) for lcd/lls; for get and put the
+// source argument is completed on the source side and the target argument on
+// the target side. Candidates are full replacements for the word being edited,
+// with directories ending in "/".
+func newCompleter(channel ssh3.Channel, localDir, remoteDir *string) completeFunc {
+	listRemote := func(dir string) ([]string, error) {
+		if dir == "." {
+			dir = *remoteDir
+		} else if dir != "/" && !path.IsAbs(dir) {
+			dir = path.Join(*remoteDir, dir)
+		}
+		resp, err := doRequest(channel, &Request{Cmd: "ls", Path: dir})
+		if err != nil {
+			return nil, err
+		}
+		if !resp.OK {
+			return nil, fmt.Errorf("%s", resp.Error)
+		}
+		names := make([]string, 0, len(resp.Entries))
+		for _, e := range resp.Entries {
+			if e.IsDir {
+				names = append(names, e.Name+"/")
+			} else {
+				names = append(names, e.Name)
+			}
+		}
+		return names, nil
+	}
+
+	listLocal := func(dir string) ([]string, error) {
+		if dir == "." {
+			dir = *localDir
+		} else if !filepath.IsAbs(dir) {
+			dir = filepath.Join(*localDir, dir)
+		}
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			return nil, err
+		}
+		names := make([]string, 0, len(entries))
+		for _, e := range entries {
+			if e.IsDir() {
+				names = append(names, e.Name()+"/")
+			} else {
+				names = append(names, e.Name())
+			}
+		}
+		return names, nil
+	}
+
+	return func(buf []rune, pos int) ([]string, int) {
+		// The word to complete is the whitespace-delimited token ending at the
+		// cursor. When the cursor sits on the command itself there is nothing
+		// to complete: only paths are completed, not commands.
+		wordStart := pos
+		for wordStart > 0 && !unicode.IsSpace(buf[wordStart-1]) {
+			wordStart--
+		}
+		if wordStart == 0 {
+			return nil, 0
+		}
+		word := string(buf[wordStart:pos])
+
+		args := strings.Fields(string(buf[:pos]))
+		if len(args) == 0 {
+			return nil, wordStart
+		}
+		cmd := args[0]
+
+		// The argument ordinal occupied by the word (1 = first argument),
+		// skipping flag arguments such as -r/--recursive.
+		argIdx := 1
+		for _, a := range args[1:] {
+			if a == word {
+				break
+			}
+			if !strings.HasPrefix(a, "-") {
+				argIdx++
+			}
+		}
+		if strings.HasPrefix(word, "-") {
+			return nil, wordStart
+		}
+
+		local := false
+		switch cmd {
+		case "lcd", "lls":
+			local = true
+		case "get":
+			local = argIdx == 2 // the target is local
+		case "put":
+			local = argIdx == 1 // the source is local
+		case "cd", "ls", "mkdir", "rm", "rmdir":
+			local = false
+		default:
+			return nil, wordStart
+		}
+
+		listDir := listRemote
+		if local {
+			listDir = listLocal
+		}
+		return completePath(word, listDir), wordStart
+	}
+}
+
+// completePath returns candidate completions for word by listing the directory
+// it refers to and matching the entries against the word's final component.
+// listDir returns the names of the entries of dir, with a trailing "/" on
+// directories. Candidates are full replacements for word, so the caller can
+// substitute them directly into the line. It returns nil when the directory
+// cannot be listed.
+func completePath(word string, listDir func(dir string) ([]string, error)) []string {
+	dir := "."
+	prefix := word
+	base := "" // the word up to and including its last "/"
+	if i := strings.LastIndex(word, "/"); i >= 0 {
+		base = word[:i+1]
+		dir = word[:i]
+		if dir == "" {
+			dir = "/"
+		}
+		if strings.HasSuffix(word, "/") {
+			prefix = "" // list the directory itself
+		} else {
+			prefix = word[i+1:]
+		}
+	}
+
+	entries, err := listDir(dir)
+	if err != nil {
+		return nil
+	}
+
+	var candidates []string
+	for _, name := range entries {
+		if prefix != "" && !strings.HasPrefix(name, prefix) {
+			continue
+		}
+		candidates = append(candidates, base+name)
+	}
+	return candidates
 }
 
 func doLs(channel ssh3.Channel, remoteDir string, parts []string) error {
@@ -573,7 +724,10 @@ func printHelp() {
   lcd <path>      change local directory
   lls [path]      list local directory
   lpwd            print local working directory
-  exit/quit       exit`)
+  exit/quit       exit
+
+Tab completes file paths: local paths for lcd/lls and for the source of put
+and target of get; remote paths for all other arguments.`)
 }
 
 func printEntry(name string, info os.FileInfo) {

--- a/sftp/completer_test.go
+++ b/sftp/completer_test.go
@@ -1,0 +1,323 @@
+package sftp
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestCompletePath verifies that completePath lists the directory the word
+// refers to and matches its entries against the word's final component,
+// returning full replacements for the word.
+func TestCompletePath(t *testing.T) {
+	listDir := func(dir string) ([]string, error) {
+		switch dir {
+		case ".":
+			return []string{"alpha.txt", "beta.txt", "docs/"}, nil
+		case "docs":
+			return []string{"alpha.txt", "beta.txt", "docs/"}, nil
+		case "/":
+			return []string{"usr/", "var/"}, nil
+		case "/usr":
+			return []string{"bin/", "lib/", "local/"}, nil
+		}
+		return nil, os.ErrNotExist
+	}
+
+	cases := []struct {
+		word string
+		want []string
+	}{
+		{"", []string{"alpha.txt", "beta.txt", "docs/"}},
+		{"a", []string{"alpha.txt"}},
+		{"doc", []string{"docs/"}},
+		{"docs/", []string{"docs/alpha.txt", "docs/beta.txt", "docs/docs/"}},
+		{"/usr/l", []string{"/usr/lib/", "/usr/local/"}},
+		{"/u", []string{"/usr/"}},
+		{"/", []string{"/usr/", "/var/"}},
+		{"missing", nil},
+	}
+	for _, c := range cases {
+		got := completePath(c.word, listDir)
+		if len(got) != len(c.want) {
+			t.Errorf("completePath(%q) = %v, want %v", c.word, got, c.want)
+			continue
+		}
+		for i := range got {
+			if got[i] != c.want[i] {
+				t.Errorf("completePath(%q) = %v, want %v", c.word, got, c.want)
+				break
+			}
+		}
+	}
+}
+
+func remoteEntries(entries ...FileInfo) []FileInfo {
+	return entries
+}
+
+func TestCompleterRemote(t *testing.T) {
+	resp := makeJSONDataMsg(&Response{OK: true, Entries: remoteEntries(
+		FileInfo{Name: "docs", IsDir: true},
+		FileInfo{Name: "file1.txt"},
+		FileInfo{Name: "file2.txt"},
+	)})
+	// One response per completer call that reaches the channel: each of the
+	// three calls below issues an ls request.
+	ch := newMockChannel(resp, resp, resp)
+	localDir, remoteDir := "/local", "/remote"
+	c := newCompleter(ch, &localDir, &remoteDir)
+
+	cands, start := c([]rune("cd fi"), 5)
+	if start != 3 {
+		t.Errorf("start = %d, want 3", start)
+	}
+	if len(cands) != 2 || cands[0] != "file1.txt" || cands[1] != "file2.txt" {
+		t.Errorf("candidates = %v, want [file1.txt file2.txt]", cands)
+	}
+	var got Request
+	if err := json.Unmarshal(ch.Writes[0], &got); err != nil {
+		t.Fatalf("unmarshal request: %v", err)
+	}
+	if got.Cmd != "ls" || got.Path != "/remote" {
+		t.Errorf("request = %s %q, want ls %q", got.Cmd, got.Path, "/remote")
+	}
+
+	// Directory entries carry a trailing "/".
+	cands, _ = c([]rune("cd d"), 4)
+	if len(cands) != 1 || cands[0] != "docs/" {
+		t.Errorf("directory candidate = %v, want [docs/]", cands)
+	}
+
+	// The word must be the second argument; the first argument is skipped.
+	cands, _ = c([]rune("cd x fi"), 7)
+	if len(cands) != 2 || cands[0] != "file1.txt" {
+		t.Errorf("second-argument candidates = %v", cands)
+	}
+
+	// No candidates when the cursor is on the command word itself.
+	if cands, start := c([]rune("cd"), 2); cands != nil || start != 0 {
+		t.Errorf("command word: got %v start=%d, want nil/0", cands, start)
+	}
+
+	// Unknown commands are not completed.
+	if cands, _ := c([]rune("frobnicate x"), 12); cands != nil {
+		t.Errorf("unknown command: got %v, want nil", cands)
+	}
+}
+
+func TestCompleterRemoteTrailingSlashListsDir(t *testing.T) {
+	ch := newMockChannel(makeJSONDataMsg(&Response{OK: true, Entries: remoteEntries(
+		FileInfo{Name: "main.go"},
+		FileInfo{Name: "util.go"},
+	)}))
+	localDir, remoteDir := "/local", "/remote"
+	c := newCompleter(ch, &localDir, &remoteDir)
+
+	cands, start := c([]rune("cd docs/m"), 9)
+	if start != 3 {
+		t.Errorf("start = %d, want 3", start)
+	}
+	// "docs/m" must list /remote/docs and match the final component.
+	if len(cands) != 1 || cands[0] != "docs/main.go" {
+		t.Errorf("candidates = %v, want [docs/main.go]", cands)
+	}
+	var got Request
+	if err := json.Unmarshal(ch.Writes[0], &got); err != nil {
+		t.Fatalf("unmarshal request: %v", err)
+	}
+	if got.Path != "/remote/docs" {
+		t.Errorf("request path = %q, want %q", got.Path, "/remote/docs")
+	}
+}
+
+func TestCompleterRemoteAbsolute(t *testing.T) {
+	ch := newMockChannel(makeJSONDataMsg(&Response{OK: true, Entries: remoteEntries(
+		FileInfo{Name: "var"},
+		FileInfo{Name: "usr", IsDir: true},
+	)}))
+	localDir, remoteDir := "/local", "/remote"
+	c := newCompleter(ch, &localDir, &remoteDir)
+
+	cands, _ := c([]rune("ls /u"), 5)
+	if len(cands) != 1 || cands[0] != "/usr/" {
+		t.Errorf("absolute candidates = %v, want [/usr/]", cands)
+	}
+	var got Request
+	if err := json.Unmarshal(ch.Writes[0], &got); err != nil {
+		t.Fatalf("unmarshal request: %v", err)
+	}
+	if got.Path != "/" {
+		t.Errorf("request path = %q, want /", got.Path)
+	}
+}
+
+func TestCompleterRemoteError(t *testing.T) {
+	ch := newMockChannel(makeJSONDataMsg(&Response{OK: false, Error: "no such file"}))
+	localDir, remoteDir := "/local", "/remote"
+	c := newCompleter(ch, &localDir, &remoteDir)
+
+	if cands, _ := c([]rune("cd nope"), 7); cands != nil {
+		t.Errorf("error listing: got %v, want nil", cands)
+	}
+}
+
+func TestCompleterLocal(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "one.txt"), nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(filepath.Join(dir, "sub"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	localDir, remoteDir := dir, "/remote"
+	c := newCompleter(nil, &localDir, &remoteDir)
+
+	cands, start := c([]rune("lls o"), 5)
+	if start != 4 {
+		t.Errorf("start = %d, want 4", start)
+	}
+	if len(cands) != 1 || cands[0] != "one.txt" {
+		t.Errorf("local candidates = %v, want [one.txt]", cands)
+	}
+
+	cands, _ = c([]rune("lcd s"), 5)
+	if len(cands) != 1 || cands[0] != "sub/" {
+		t.Errorf("local directory candidate = %v, want [sub/]", cands)
+	}
+}
+
+func TestCompleterGetPutSides(t *testing.T) {
+	// get: the source argument is remote, the target is local.
+	// Two completer calls reach the channel (get source and put target), each
+	// needs its own ls response.
+	ch := newMockChannel(
+		makeJSONDataMsg(&Response{OK: true, Entries: remoteEntries(
+			FileInfo{Name: "remote.txt"},
+		)}),
+		makeJSONDataMsg(&Response{OK: true, Entries: remoteEntries(
+			FileInfo{Name: "remote.txt"},
+		)}),
+	)
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "local.txt"), nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	localDir, remoteDir := dir, "/remote"
+	c := newCompleter(ch, &localDir, &remoteDir)
+
+	cands, _ := c([]rune("get r"), 5)
+	if len(cands) != 1 || cands[0] != "remote.txt" {
+		t.Errorf("get source (remote) = %v, want [remote.txt]", cands)
+	}
+
+	cands, _ = c([]rune("get remote.txt "), 15)
+	if len(cands) != 1 || cands[0] != "local.txt" {
+		t.Errorf("get target (local) = %v, want [local.txt]", cands)
+	}
+
+	// put: the source argument is local, the target is remote.
+	cands, _ = c([]rune("put l"), 5)
+	if len(cands) != 1 || cands[0] != "local.txt" {
+		t.Errorf("put source (local) = %v, want [local.txt]", cands)
+	}
+
+	cands, _ = c([]rune("put local.txt r"), 15)
+	if len(cands) != 1 || cands[0] != "remote.txt" {
+		t.Errorf("put target (remote) = %v, want [remote.txt]", cands)
+	}
+
+	// Flags such as -r are skipped when counting the argument.
+	cands, _ = c([]rune("put -r l"), 7)
+	if len(cands) != 1 || cands[0] != "local.txt" {
+		t.Errorf("put -r source (local) = %v, want [local.txt]", cands)
+	}
+}
+
+// TestEditorRemoteTabCompletion drives the full line editor against a mock
+// sftp channel: the first Tab completes to the common prefix of a remote
+// listing, the second Tab lists the candidates, and a further Tab on a typed
+// suffix completes a unique file inside the resolved directory.
+func TestEditorRemoteTabCompletion(t *testing.T) {
+	q := newQueuedMockChannel()
+	q.enqueue(
+		makeJSONDataMsg(&Response{OK: true, Entries: remoteEntries(
+			FileInfo{Name: "src", IsDir: true},
+			FileInfo{Name: "src.tar.gz"},
+		)}),
+		makeJSONDataMsg(&Response{OK: true, Entries: remoteEntries(
+			FileInfo{Name: "src", IsDir: true},
+			FileInfo{Name: "src.tar.gz"},
+		)}),
+		makeJSONDataMsg(&Response{OK: true, Entries: remoteEntries(
+			FileInfo{Name: "main.go"},
+			FileInfo{Name: "util.go"},
+		)}),
+	)
+	localDir, remoteDir := "/local", "/remote"
+	var out bytes.Buffer
+	e := &lineEditor{
+		reader:    bufio.NewReader(strings.NewReader("cd s\t\t/m\t\r")),
+		out:       &out,
+		outFd:     -1,
+		width:     80,
+		prompt:    "sftp> ",
+		histPos:   -1,
+		completer: newCompleter(q, &localDir, &remoteDir),
+	}
+	line := readWithTimeout(t, e, 5*time.Second)
+	if line != "cd src/main.go " {
+		t.Errorf("line = %q, want %q", line, "cd src/main.go ")
+	}
+	if !strings.Contains(out.String(), "src.tar.gz") {
+		t.Errorf("second tab should list candidates, got output %q", out.String())
+	}
+
+	// Three ls requests: the working directory (twice, for the completion and
+	// the candidate listing) and the resolved subdirectory.
+	writes := q.Writes()
+	if len(writes) != 3 {
+		t.Fatalf("expected 3 requests, got %d", len(writes))
+	}
+	for i, want := range []string{"/remote", "/remote", "/remote/src"} {
+		var got Request
+		if err := json.Unmarshal(writes[i], &got); err != nil {
+			t.Fatalf("unmarshal request %d: %v", i, err)
+		}
+		if got.Cmd != "ls" || got.Path != want {
+			t.Errorf("request %d = %s %q, want ls %q", i, got.Cmd, got.Path, want)
+		}
+	}
+}
+
+// readWithTimeout runs e.read in a goroutine and fails the test if it does not
+// return within the given duration. Completion tests that drive a mock sftp
+// channel must fail fast instead of hanging the suite when a request is left
+// unanswered.
+func readWithTimeout(t *testing.T, e *lineEditor, d time.Duration) string {
+	t.Helper()
+	type result struct {
+		line string
+		err  error
+	}
+	done := make(chan result, 1)
+	go func() {
+		line, err := e.read()
+		done <- result{line, err}
+	}()
+	select {
+	case r := <-done:
+		if r.err != nil {
+			t.Fatalf("read: %v", r.err)
+		}
+		return r.line
+	case <-time.After(d):
+		t.Fatalf("line editor read timed out after %s", d)
+		return ""
+	}
+}

--- a/sftp/readline.go
+++ b/sftp/readline.go
@@ -16,6 +16,12 @@ import (
 // history navigation.
 const maxHistory = 500
 
+// completeFunc returns candidate completions for the word being edited and the
+// index into buf at which the word starts. Each candidate is a full
+// replacement for the word (not just its final path component), so the caller
+// can substitute it directly into the line; directory candidates end with "/".
+type completeFunc func(buf []rune, pos int) (candidates []string, start int)
+
 // interactiveReader reads lines of interactive input for the SFTP shell. It
 // uses readline-style editing (raw mode) when stdin and stdout are terminals,
 // and falls back to plain line scanning otherwise (e.g. piped input). The
@@ -99,6 +105,10 @@ type lineEditor struct {
 	history []string
 	histPos int    // index into history while navigating, -1 when editing a fresh line
 	stash   string // draft line saved when starting to navigate history
+	// tab completion state
+	completer completeFunc
+	tabWord   string // word completed by the last Tab press
+	tabActive bool   // whether the next Tab on the same word lists the candidates
 }
 
 func (e *lineEditor) read() (string, error) {
@@ -113,6 +123,14 @@ func (e *lineEditor) read() (string, error) {
 		if err != nil {
 			return "", err
 		}
+
+		if b == '\t' { // Tab: complete the word before the cursor
+			e.complete()
+			continue
+		}
+		// Any other key invalidates the pending tab-completion listing.
+		e.tabActive = false
+		e.tabWord = ""
 
 		switch {
 		case b == '\r' || b == '\n': // Enter
@@ -490,6 +508,167 @@ func (e *lineEditor) deleteWordBeforeCursor() {
 
 func isWordSep(r rune) bool {
 	return r == ' ' || r == '\t'
+}
+
+// complete performs tab completion for the word before the cursor, delegating
+// to the configured completer. A single candidate is applied in full (with a
+// trailing space for files, so the next argument can be typed); several
+// candidates are completed to their longest common prefix; and a second Tab on
+// the same word lists the candidates below the prompt. When nothing matches,
+// the terminal bell is rung.
+func (e *lineEditor) complete() {
+	if e.completer == nil {
+		return
+	}
+
+	candidates, start := e.completer(e.buf, e.pos)
+	if len(candidates) == 0 {
+		fmt.Fprint(e.out, "\a") // bell: nothing to complete
+		e.tabActive, e.tabWord = false, ""
+		return
+	}
+
+	word := string(e.buf[start:e.pos])
+
+	// A second consecutive Tab on the same word lists the candidates instead
+	// of completing again.
+	if e.tabActive && e.tabWord == word {
+		e.printCandidates(candidates)
+		e.tabActive, e.tabWord = false, ""
+		return
+	}
+
+	if len(candidates) == 1 {
+		// Unique match: apply it in full. Directories already carry a trailing
+		// "/"; files get a trailing space so the next argument can be typed
+		// without a second Tab.
+		c := candidates[0]
+		if !strings.HasSuffix(c, "/") {
+			c += " "
+		}
+		e.replaceRange(start, e.pos, []rune(c))
+		e.tabActive, e.tabWord = false, ""
+		return
+	}
+
+	prefix := commonPrefix(candidates)
+	if prefix == word {
+		// Already at the common prefix: show the candidates.
+		e.printCandidates(candidates)
+		e.tabActive, e.tabWord = false, ""
+		return
+	}
+	e.replaceRange(start, e.pos, []rune(prefix))
+	e.tabActive, e.tabWord = true, prefix
+}
+
+// printCandidates lists the completion candidates below the prompt, laid out
+// in columns fitted to the terminal width (top-to-bottom, like ls), and
+// redraws the prompt and line above them. The listing stays visible until the
+// next edit, which clears it.
+func (e *lineEditor) printCandidates(candidates []string) {
+	e.refreshWidth()
+
+	// Move to the end of the current line and start the listing on the next
+	// row.
+	total := displayWidth(e.prompt) + displayWidth(string(e.buf))
+	e.moveCursorTo(total)
+	fmt.Fprint(e.out, "\r\n")
+	e.curRow, e.curCol = e.curRow+1, 0
+
+	// Each column is as wide as the longest candidate plus two spaces of
+	// separation.
+	maxw := 0
+	for _, c := range candidates {
+		if w := displayWidth(c); w > maxw {
+			maxw = w
+		}
+	}
+	ncols := 1
+	if maxw > 0 {
+		if c := e.width / (maxw + 2); c > ncols {
+			ncols = c
+		}
+	}
+	if ncols > len(candidates) {
+		ncols = len(candidates)
+	}
+	nrows := (len(candidates) + ncols - 1) / ncols
+	if nrows == 0 {
+		nrows = 1
+	}
+
+	for row := 0; row < nrows; row++ {
+		for col := 0; col < ncols; col++ {
+			idx := col*nrows + row
+			if idx >= len(candidates) {
+				continue
+			}
+			c := candidates[idx]
+			fmt.Fprint(e.out, c)
+			if col < ncols-1 {
+				for i := displayWidth(c); i < maxw+2; i++ {
+					fmt.Fprint(e.out, " ")
+				}
+			}
+		}
+		fmt.Fprint(e.out, "\r\n")
+	}
+	e.curRow += nrows
+	e.curCol = 0
+
+	e.redrawNoClear()
+}
+
+// redrawNoClear redraws the prompt and the line without clearing the rows
+// below them, so completion candidates printed under the prompt stay visible
+// until the next edit.
+func (e *lineEditor) redrawNoClear() {
+	e.refreshWidth()
+	p := displayWidth(e.prompt)
+	total := p + displayWidth(string(e.buf))
+
+	if e.curRow > 0 {
+		fmt.Fprintf(e.out, "\x1b[%dA", e.curRow)
+	}
+	fmt.Fprint(e.out, "\r")
+	fmt.Fprint(e.out, e.prompt)
+	fmt.Fprint(e.out, string(e.buf))
+
+	e.curRow, e.curCol = total/e.width, total%e.width
+	e.moveCursorTo(p + displayWidth(string(e.buf[:e.pos])))
+}
+
+// replaceRange replaces buf[start:end] with repl and positions the cursor at
+// the end of the replacement.
+func (e *lineEditor) replaceRange(start, end int, repl []rune) {
+	buf := make([]rune, 0, len(e.buf)-(end-start)+len(repl))
+	buf = append(buf, e.buf[:start]...)
+	buf = append(buf, repl...)
+	buf = append(buf, e.buf[end:]...)
+	e.buf = buf
+	e.pos = start + len(repl)
+	e.render()
+}
+
+// commonPrefix returns the longest common prefix shared by all of strs.
+func commonPrefix(strs []string) string {
+	if len(strs) == 0 {
+		return ""
+	}
+	prefix := []rune(strs[0])
+	for _, s := range strs[1:] {
+		r := []rune(s)
+		n := 0
+		for n < len(prefix) && n < len(r) && prefix[n] == r[n] {
+			n++
+		}
+		prefix = prefix[:n]
+		if len(prefix) == 0 {
+			break
+		}
+	}
+	return string(prefix)
 }
 
 // displayWidth returns the number of terminal columns s occupies when

--- a/sftp/readline_test.go
+++ b/sftp/readline_test.go
@@ -202,6 +202,181 @@ func TestLineEditorRendering(t *testing.T) {
 	}
 }
 
+// tabCompleter returns a static completer whose candidates are the words
+// starting with the token being edited, used to drive the line editor's tab
+// completion without a filesystem.
+func tabCompleter(all []string) completeFunc {
+	return func(buf []rune, pos int) ([]string, int) {
+		start := pos
+		for start > 0 && buf[start-1] != ' ' {
+			start--
+		}
+		word := string(buf[start:pos])
+		var out []string
+		for _, c := range all {
+			if strings.HasPrefix(c, word) {
+				out = append(out, c)
+			}
+		}
+		return out, start
+	}
+}
+
+func TestLineEditorTabCompletionUniqueFile(t *testing.T) {
+	var out bytes.Buffer
+	e := &lineEditor{
+		reader:    bufio.NewReader(strings.NewReader("cd dir/fi\t\r")),
+		out:       &out,
+		outFd:     -1,
+		width:     80,
+		prompt:    "sftp> ",
+		histPos:   -1,
+		completer: tabCompleter([]string{"dir/file"}),
+	}
+	line, err := e.read()
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	// A unique file match is applied in full and followed by a space so the
+	// next argument can be typed immediately.
+	if line != "cd dir/file " {
+		t.Errorf("unique file completion: got %q, want %q", line, "cd dir/file ")
+	}
+}
+
+func TestLineEditorTabCompletionUniqueDirectory(t *testing.T) {
+	var out bytes.Buffer
+	e := &lineEditor{
+		reader:    bufio.NewReader(strings.NewReader("cd dir/su\t\r")),
+		out:       &out,
+		outFd:     -1,
+		width:     80,
+		prompt:    "sftp> ",
+		histPos:   -1,
+		completer: tabCompleter([]string{"dir/sub/"}),
+	}
+	line, err := e.read()
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	// A unique directory keeps its trailing "/" (no space), so a further Tab
+	// descends into it.
+	if line != "cd dir/sub/" {
+		t.Errorf("unique directory completion: got %q, want %q", line, "cd dir/sub/")
+	}
+}
+
+func TestLineEditorTabCompletionCommonPrefix(t *testing.T) {
+	var out bytes.Buffer
+	e := &lineEditor{
+		reader:    bufio.NewReader(strings.NewReader("cd dir/pa\t\r")),
+		out:       &out,
+		outFd:     -1,
+		width:     80,
+		prompt:    "sftp> ",
+		histPos:   -1,
+		completer: tabCompleter([]string{"dir/part1", "dir/part2"}),
+	}
+	line, err := e.read()
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if line != "cd dir/part" {
+		t.Errorf("common prefix completion: got %q, want %q", line, "cd dir/part")
+	}
+}
+
+func TestLineEditorTabCompletionSecondTabLists(t *testing.T) {
+	var out bytes.Buffer
+	e := &lineEditor{
+		reader:    bufio.NewReader(strings.NewReader("cd dir/pa\t\t\r")),
+		out:       &out,
+		outFd:     -1,
+		width:     80,
+		prompt:    "sftp> ",
+		histPos:   -1,
+		completer: tabCompleter([]string{"dir/part1", "dir/part2"}),
+	}
+	line, err := e.read()
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	// The first Tab completes to the common prefix; the second lists the
+	// candidates below the prompt without changing the line.
+	if line != "cd dir/part" {
+		t.Errorf("second tab line: got %q, want %q", line, "cd dir/part")
+	}
+	if !strings.Contains(out.String(), "dir/part1") || !strings.Contains(out.String(), "dir/part2") {
+		t.Errorf("second tab should list candidates, got output %q", out.String())
+	}
+}
+
+func TestLineEditorTabCompletionNoCandidates(t *testing.T) {
+	var out bytes.Buffer
+	e := &lineEditor{
+		reader:    bufio.NewReader(strings.NewReader("cd nope\t\r")),
+		out:       &out,
+		outFd:     -1,
+		width:     80,
+		prompt:    "sftp> ",
+		histPos:   -1,
+		completer: tabCompleter([]string{"dir/file"}),
+	}
+	line, err := e.read()
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if line != "cd nope" {
+		t.Errorf("no-match line: got %q, want %q", line, "cd nope")
+	}
+	if !strings.Contains(out.String(), "\a") {
+		t.Errorf("no-match completion should ring the bell, got output %q", out.String())
+	}
+}
+
+func TestLineEditorTabCompletionMidLine(t *testing.T) {
+	// The cursor sits in the middle of the line; completion must only touch
+	// the word ending at the cursor and leave the rest of the line intact.
+	var out bytes.Buffer
+	e := &lineEditor{
+		reader:    bufio.NewReader(strings.NewReader("get dir/fi suffix\x1b[D\x1b[D\x1b[D\x1b[D\x1b[D\x1b[D\x1b[D\t\r")),
+		out:       &out,
+		outFd:     -1,
+		width:     80,
+		prompt:    "sftp> ",
+		histPos:   -1,
+		completer: tabCompleter([]string{"dir/file", "other"}),
+	}
+	line, err := e.read()
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	// "get dir/fi suffix" is 17 chars; moving 13 left lands the cursor after
+	// "dir/fi"; Tab completes it to "dir/file " in place.
+	if line != "get dir/file  suffix" {
+		t.Errorf("mid-line completion: got %q, want %q", line, "get dir/file  suffix")
+	}
+}
+
+func TestCommonPrefix(t *testing.T) {
+	cases := []struct {
+		in   []string
+		want string
+	}{
+		{[]string{"dir/part1", "dir/part2"}, "dir/part"},
+		{[]string{"a", "ab", "abc"}, "a"},
+		{[]string{"abc"}, "abc"},
+		{[]string{"x", "y"}, ""},
+		{[]string{"中文1", "中文2"}, "中文"},
+		{[]string{}, ""},
+	}
+	for _, c := range cases {
+		if got := commonPrefix(c.in); got != c.want {
+			t.Errorf("commonPrefix(%v) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
 func TestDisplayWidth(t *testing.T) {
 	cases := []struct {
 		in   string


### PR DESCRIPTION
Tab completes the path being typed against the remote filesystem (for cd, ls, mkdir, rm, rmdir, and the get source / put target) or the local filesystem (for lcd, lls, and the get target / put source). A unique match is applied in full - directories keep a trailing '/' while files get a trailing space - several matches complete to their longest common prefix, and a second Tab on the same word lists the candidates below the prompt in columns. Remote completions are resolved over the sftp channel, so they track the remote working directory.