### PR TITLE
OpenSSH-style path quoting and escaping in the SFTP client

### DIFF
--- a/sftp/client.go
+++ b/sftp/client.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 	"unicode"
+	"unicode/utf8"
 
 	ssh3 "github.com/h4sh5/sshoq"
 	"github.com/h4sh5/sshoq/client"
@@ -47,13 +48,22 @@ func RunInteractiveClient(c *client.Client) error {
 			return err
 		}
 
-		line = strings.TrimSpace(line)
-		if line == "" {
+		// Split the line into arguments with OpenSSH sftp quoting: single and
+		// double quotes protect whitespace and metacharacters, backslash
+		// escapes the next character, and '#' starts a comment. Glob
+		// metacharacters keep their escaping for commands that glob; commands
+		// that do not glob un-escape their paths via undoGlobEscape/unescape
+		// when they consume them.
+		parts, _, _, _, err := makeargv(line, false)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "%s\n", err)
+			continue
+		}
+		if len(parts) == 0 {
 			continue
 		}
 
-		parts := strings.Fields(line)
-		cmd := parts[0]
+		cmd := strings.ToLower(parts[0])
 
 		switch cmd {
 		case "exit", "quit":
@@ -64,7 +74,7 @@ func RunInteractiveClient(c *client.Client) error {
 				fmt.Println("usage: lcd <local-path>")
 				continue
 			}
-			if err := os.Chdir(parts[1]); err != nil {
+			if err := os.Chdir(undoGlobEscape(parts[1])); err != nil {
 				fmt.Fprintf(os.Stderr, "lcd: %s\n", err)
 			} else {
 				localDir, _ = os.Getwd()
@@ -73,7 +83,7 @@ func RunInteractiveClient(c *client.Client) error {
 		case "lls":
 			target := localDir
 			if len(parts) > 1 {
-				target = filepath.Join(localDir, parts[1])
+				target = filepath.Join(localDir, undoGlobEscape(parts[1]))
 			}
 			entries, err := os.ReadDir(target)
 			if err != nil {
@@ -91,10 +101,11 @@ func RunInteractiveClient(c *client.Client) error {
 		case "cd":
 			target := remoteDir
 			if len(parts) > 1 {
-				if path.IsAbs(parts[1]) {
-					target = parts[1]
+				arg := undoGlobEscape(parts[1])
+				if path.IsAbs(arg) {
+					target = arg
 				} else {
-					target = path.Join(remoteDir, parts[1])
+					target = path.Join(remoteDir, arg)
 				}
 			}
 			resp, err := doRequest(channel, &Request{Cmd: "cd", Path: target})
@@ -141,11 +152,13 @@ func RunInteractiveClient(c *client.Client) error {
 				fmt.Println(err.Error())
 				continue
 			}
-			localFile := localSource
+			// The source is not globbed by this client, so the escaped path is
+			// fully un-escaped to the literal file name.
+			localFile := unescape(localSource)
 			if !filepath.IsAbs(localFile) {
 				localFile = filepath.Join(localDir, localFile)
 			}
-			remoteFile := remoteTarget
+			remoteFile := undoGlobEscape(remoteTarget)
 			if remoteFile == "" {
 				remoteFile = filepath.Base(localFile)
 			}
@@ -166,7 +179,7 @@ func RunInteractiveClient(c *client.Client) error {
 				fmt.Println("usage: mkdir <remote-path>")
 				continue
 			}
-			target := parts[1]
+			target := undoGlobEscape(parts[1])
 			if !path.IsAbs(target) {
 				target = path.Join(remoteDir, target)
 			}
@@ -184,7 +197,9 @@ func RunInteractiveClient(c *client.Client) error {
 				fmt.Println("usage: rm <remote-file>")
 				continue
 			}
-			target := parts[1]
+			// rm is a glob command in OpenSSH; this client removes a single
+			// literal path, so the escaping is fully undone.
+			target := unescape(parts[1])
 			if !path.IsAbs(target) {
 				target = path.Join(remoteDir, target)
 			}
@@ -202,7 +217,7 @@ func RunInteractiveClient(c *client.Client) error {
 				fmt.Println("usage: rmdir <remote-dir>")
 				continue
 			}
-			target := parts[1]
+			target := undoGlobEscape(parts[1])
 			if !path.IsAbs(target) {
 				target = path.Join(remoteDir, target)
 			}
@@ -281,37 +296,53 @@ func newCompleter(channel ssh3.Channel, localDir, remoteDir *string) completeFun
 	}
 
 	return func(buf []rune, pos int) ([]string, int) {
-		// The word to complete is the whitespace-delimited token ending at the
-		// cursor. When the cursor sits on the command itself there is nothing
-		// to complete: only paths are completed, not commands.
-		wordStart := pos
-		for wordStart > 0 && !unicode.IsSpace(buf[wordStart-1]) {
-			wordStart--
-		}
-		if wordStart == 0 {
+		// Parse the line up to the cursor with the OpenSSH quoting rules in
+		// sloppy mode, so an unterminated quote (the user is mid-argument) is
+		// tolerated. The last argument is the one being completed.
+		prefix := string(buf[:pos])
+		args, spans, quote, terminated, _ := makeargv(prefix, true)
+		if len(args) == 0 {
 			return nil, 0
 		}
-		word := string(buf[wordStart:pos])
 
-		args := strings.Fields(string(buf[:pos]))
-		if len(args) == 0 {
-			return nil, wordStart
+		// When the cursor sits on whitespace the word being completed is the
+		// (empty) next argument at the cursor; otherwise it is the argument
+		// containing the cursor, replaced from where that argument begins
+		// (including its opening quote, if any) to the cursor. The spans are
+		// byte offsets into prefix, so they are converted to rune indices
+		// into buf.
+		runeAt := func(b int) int {
+			if b <= 0 {
+				return 0
+			}
+			return utf8.RuneCountInString(prefix[:b])
 		}
-		cmd := args[0]
+		start := pos
+		parsedWord := ""
+		if pos > 0 && !unicode.IsSpace(buf[pos-1]) {
+			start = runeAt(spans[len(spans)-1][0])
+			parsedWord = args[len(args)-1]
+			if len(args) == 1 {
+				return nil, 0 // the cursor is on the command word itself
+			}
+		}
+
+		cmd := strings.ToLower(args[0])
 
 		// The argument ordinal occupied by the word (1 = first argument),
-		// skipping flag arguments such as -r/--recursive.
+		// skipping flag arguments such as -r/--recursive. When the cursor is
+		// at an argument boundary the word is the next (empty) argument.
 		argIdx := 1
 		for _, a := range args[1:] {
-			if a == word {
+			if a == parsedWord {
 				break
 			}
 			if !strings.HasPrefix(a, "-") {
 				argIdx++
 			}
 		}
-		if strings.HasPrefix(word, "-") {
-			return nil, wordStart
+		if strings.HasPrefix(parsedWord, "-") {
+			return nil, start
 		}
 
 		local := false
@@ -325,14 +356,37 @@ func newCompleter(channel ssh3.Channel, localDir, remoteDir *string) completeFun
 		case "cd", "ls", "mkdir", "rm", "rmdir":
 			local = false
 		default:
-			return nil, wordStart
+			return nil, start
 		}
 
 		listDir := listRemote
 		if local {
 			listDir = listLocal
 		}
-		return completePath(word, listDir), wordStart
+		candidates := completePath(unescape(parsedWord), listDir)
+
+		// Render the candidates in the typed form, escaping the characters
+		// that are special to the command line. When the completed word sits
+		// inside quotes (an open quote at the cursor, or a word that already
+		// starts with one), the candidate is re-quoted: only the quote
+		// character itself needs escaping inside the quotes, and the quote is
+		// closed when the user's was still open.
+		quoted := quote != 0 && !terminated
+		var q byte
+		if quoted {
+			q = quote
+		} else if start < pos && (buf[start] == '\'' || buf[start] == '"') {
+			quoted = true
+			q = byte(buf[start])
+		}
+		for i, c := range candidates {
+			if quoted {
+				candidates[i] = string(q) + escapePath(c, q) + string(q)
+			} else {
+				candidates[i] = escapePath(c, 0)
+			}
+		}
+		return candidates, start
 	}
 }
 
@@ -391,6 +445,9 @@ func doLs(channel ssh3.Channel, remoteDir string, parts []string) error {
 		listDir = dir
 		pattern = pat
 	}
+	// The directory (whether globbed or not) is a literal path: remove the
+	// escaping makeargv preserved for glob matching.
+	listDir = unescape(listDir)
 
 	// Resolve the directory relative to the remote working directory, mirroring
 	// the handling of a non-glob "ls <path>".
@@ -458,6 +515,9 @@ func doGet(channel ssh3.Channel, localDir, remoteDir string, parts []string) err
 		sourceDir = dir
 		pattern = pat
 	}
+	// The directory (whether globbed or not) is a literal path: remove the
+	// escaping makeargv preserved for glob matching.
+	sourceDir = unescape(sourceDir)
 
 	// Resolve the source relative to the remote working directory, mirroring the
 	// handling of a non-glob "get <path>".
@@ -500,7 +560,9 @@ func doGet(channel ssh3.Channel, localDir, remoteDir string, parts []string) err
 
 	// No glob: preserve the previous single-target behavior.
 	remoteFile := sourceDir
-	localFile := localTarget
+	// The local target is not globbed: undo the escaping of glob
+	// metacharacters, mirroring OpenSSH's undo_glob_escape for get targets.
+	localFile := undoGlobEscape(localTarget)
 	if localFile == "" {
 		localFile = filepath.Base(filepath.Clean(remoteFile))
 	}
@@ -519,10 +581,13 @@ func downloadOne(channel ssh3.Channel, remoteFile, localFile string, recursive b
 	return downloadFile(channel, remoteFile, localFile)
 }
 
-// globSplit reports whether arg contains glob metacharacters in its final path
-// component and, if so, returns the directory prefix (before the last "/") and
-// the pattern (the final component) to match against directory entries. When arg
-// has no metacharacters it returns ("", "", false).
+// globSplit reports whether arg contains unescaped glob metacharacters in its
+// final path component and, if so, returns the directory prefix (before the
+// last "/") and the pattern (the final component) to match against directory
+// entries. Metacharacters escaped by a backslash (*, ?, [ preceded by \\,
+// which makeargv preserves for glob matching) are literal and do not turn the
+// argument into a glob. When arg has no unescaped metacharacters it returns
+// ("", "", false).
 func globSplit(arg string) (dir, pattern string, ok bool) {
 	// The final path component starts after the last "/".
 	slash := -1
@@ -536,16 +601,22 @@ func globSplit(arg string) (dir, pattern string, ok bool) {
 		component = arg[slash+1:]
 	}
 
+	hasMeta := false
 	for i := 0; i < len(component); i++ {
 		switch component[i] {
+		case '\\':
+			i++ // skip the escaped character: it is literal
 		case '*', '?', '[':
-			if slash < 0 {
-				return "", arg, true
-			}
-			return arg[:slash], arg[slash+1:], true
+			hasMeta = true
 		}
 	}
-	return "", "", false
+	if !hasMeta {
+		return "", "", false
+	}
+	if slash < 0 {
+		return "", arg, true
+	}
+	return arg[:slash], arg[slash+1:], true
 }
 
 func parseTransferArgs(parts []string, cmd string) (recursive bool, source string, target string, err error) {
@@ -726,8 +797,12 @@ func printHelp() {
   lpwd            print local working directory
   exit/quit       exit
 
-Tab completes file paths: local paths for lcd/lls and for the source of put
-and target of get; remote paths for all other arguments.`)
+Paths are parsed like OpenSSH sftp: single quotes ('...') and double quotes
+("...") protect spaces and metacharacters, and a backslash escapes the next
+character (e.g. get 'Downloads/Test File.txt' or put Test\ File.txt).
+A '#' outside quotes starts a comment. Tab completes file paths: local paths
+for lcd/lls and for the source of put and target of get; remote paths for all
+other arguments.`)
 }
 
 func printEntry(name string, info os.FileInfo) {

--- a/sftp/quoting.go
+++ b/sftp/quoting.go
@@ -1,0 +1,259 @@
+package sftp
+
+import (
+	"errors"
+	"strings"
+)
+
+// errUnterminated is returned by makeargv in strict mode when a quote is left
+// open at the end of the line, mirroring OpenSSH's "Unterminated quoted
+// argument" error.
+var errUnterminated = errors.New("unterminated quoted argument")
+
+// makeargv splits a command line into arguments using the same quoting,
+// comment and escaping rules as the OpenSSH sftp client (sftp.c makeargv):
+//
+//   - Whitespace separates arguments except inside single or double quotes.
+//   - Single quotes ('…') protect every character literally: the only
+//     character that cannot appear inside single quotes is a single quote.
+//   - Double quotes ("…") protect most characters; inside double quotes a
+//     backslash escapes the next character (but only when followed by a
+//     double-quote, a glob metacharacter, or another backslash).
+//   - Outside quotes, a backslash escapes the next character, except when
+//     followed by ?, [, *, or \ — those sequences are preserved verbatim so
+//     that glob(3) can undo the escaping. All other backslash sequences are
+//     replaced by the following character.
+//   - A '#' outside quotes starts a comment that runs to the end of the line.
+//
+// When sloppy is true, an unterminated quote at the end of the line is
+// tolerated (used for tab completion); otherwise it is an error.
+//
+// It returns the list of arguments, the byte span of each argument in the
+// input line (start and end offsets), the quote character that opened the
+// last argument ('\0' when unquoted), and whether the quoting of the last
+// argument was properly terminated.
+func makeargv(line string, sloppy bool) (args []string, spans [][2]int, lastquote byte, terminated bool, err error) {
+	const (
+		stStart = iota
+		stSQuote
+		stDQuote
+		stUnquoted
+	)
+
+	terminated = true
+	state := stStart
+	var cur []byte
+	argStart := -1
+
+	// finishArg records the current argument when the state is stUnquoted.
+	finishArg := func(end int) {
+		if state == stUnquoted {
+			args = append(args, string(cur))
+			spans = append(spans, [2]int{argStart, end})
+			state = stStart
+			cur = cur[:0]
+			argStart = -1
+		}
+	}
+
+	i := 0
+	for i < len(line) {
+		c := line[i]
+
+		switch {
+		case c == ' ' || c == '\t' || c == '\r' || c == '\n':
+			if state == stUnquoted {
+				finishArg(i)
+			} else if state != stStart {
+				// Whitespace inside quotes is preserved.
+				cur = append(cur, c)
+			}
+
+		case c == '\'' || c == '"':
+			q := stDQuote
+			if c == '\'' {
+				q = stSQuote
+			}
+			switch state {
+			case stStart:
+				argStart = i
+				state = q
+				lastquote = c
+			case stUnquoted:
+				state = q
+				lastquote = c
+			default:
+				if state == q {
+					// Closing quote for the open quote type.
+					state = stUnquoted
+				} else {
+					// Mismatched quote inside a quoted string is literal.
+					cur = append(cur, c)
+				}
+			}
+
+		case c == '\\':
+			next := byte(0)
+			if i+1 < len(line) {
+				next = line[i+1]
+			}
+
+			if state == stSQuote || state == stDQuote {
+				quot := byte('\'')
+				if state == stDQuote {
+					quot = '"'
+				}
+				switch {
+				case next == quot:
+					// Escaped quote inside the same quote type.
+					i++
+					cur = append(cur, line[i])
+				case next == '?' || next == '[' || next == '*':
+					// Triple-escaped glob: \\ + \ + char, matching OpenSSH's
+					// double-escaped glob sequence; glob(3)/path.Match undo one
+					// level of escaping, yielding \ + literal char.
+					cur = append(cur, '\\', '\\', '\\', next)
+					i++
+				default:
+					// \x inside quotes survives as \x (the only characters
+					// treated specially are the quote and glob metacharacters).
+					cur = append(cur, '\\')
+					if next != 0 {
+						cur = append(cur, next)
+						i++
+					}
+				}
+			} else {
+				if state == stStart {
+					argStart = i
+					state = stUnquoted
+					lastquote = 0
+				}
+				switch {
+				case next == '?' || next == '[' || next == '*' || next == '\\':
+					// Preserve the backslash so glob matching can undo it.
+					cur = append(cur, c, next)
+					i++
+				case next == 0:
+					// Trailing backslash at end of line.
+					if sloppy {
+						finishArg(i)
+						return args, spans, lastquote, false, nil
+					}
+					return nil, nil, 0, false, errUnterminated
+				default:
+					// Unescape: remove the backslash, keep the next char.
+					cur = append(cur, next)
+					i++
+				}
+			}
+
+		case c == '#':
+			if state == stSQuote || state == stDQuote {
+				cur = append(cur, c)
+			} else {
+				// '#' outside quotes starts a comment.
+				finishArg(i)
+				return args, spans, lastquote, terminated, nil
+			}
+
+		default:
+			if state == stStart {
+				argStart = i
+				state = stUnquoted
+				lastquote = 0
+			}
+			if (state == stSQuote || state == stDQuote) && (c == '?' || c == '[' || c == '*') {
+				// Escape quoted glob metacharacters so they are matched
+				// literally by glob(3) / path.Match.
+				cur = append(cur, '\\', c)
+			} else {
+				cur = append(cur, c)
+			}
+		}
+
+		i++
+	}
+
+	// End of input reached.
+	if state == stSQuote || state == stDQuote {
+		if sloppy {
+			terminated = false
+			state = stUnquoted
+			finishArg(i)
+			return args, spans, lastquote, terminated, nil
+		}
+		return nil, nil, 0, false, errUnterminated
+	}
+	finishArg(i)
+	return args, spans, lastquote, terminated, nil
+}
+
+// undoGlobEscape removes the escaping of glob metacharacters that makeargv
+// preserves for glob(3) matching. For commands that do not glob (cd, mkdir,
+// rmdir, get-target, put-target, lcd, lls), the backslash before ?, [, *, or
+// \ is removed so that the literal path is used. Other backslash sequences
+// (\x) are preserved unchanged.
+func undoGlobEscape(s string) string {
+	if !strings.ContainsRune(s, '\\') {
+		return s
+	}
+	var b strings.Builder
+	b.Grow(len(s))
+	for i := 0; i < len(s); i++ {
+		if s[i] == '\\' && i+1 < len(s) {
+			switch s[i+1] {
+			case '?', '[', '*', '\\':
+				b.WriteByte(s[i+1])
+				i++
+				continue
+			}
+		}
+		b.WriteByte(s[i])
+	}
+	return b.String()
+}
+
+// unescape removes all backslash escaping from s, turning \X into X for any
+// X. This is the inverse of the quoting and escaping applied by makeargv, so
+// it yields the literal path the user intended.
+func unescape(s string) string {
+	if !strings.ContainsRune(s, '\\') {
+		return s
+	}
+	var b strings.Builder
+	b.Grow(len(s))
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c == '\\' {
+			if i+1 < len(s) {
+				i++
+				c = s[i]
+			} else {
+				continue // trailing backslash: nothing to escape
+			}
+		}
+		b.WriteByte(c)
+	}
+	return b.String()
+}
+
+// escapePath escapes s for typed insertion on the command line. Characters
+// that are special to the shell quoting are prefixed with a backslash, except
+// when they are already protected by the given quote character (quote != 0).
+// The backslash itself is always escaped for round-trip correctness.
+func escapePath(s string, quote byte) string {
+	var b strings.Builder
+	b.Grow(len(s) + 4)
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch c {
+		case '\'', '"', '\\', '\t', '[', '?', ' ', '#', '*':
+			if quote == 0 || c == quote || c == '\\' {
+				b.WriteByte('\\')
+			}
+		}
+		b.WriteByte(c)
+	}
+	return b.String()
+}

--- a/sftp/quoting_test.go
+++ b/sftp/quoting_test.go
@@ -1,0 +1,783 @@
+package sftp
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestMakeargvEmpty(t *testing.T) {
+	args, spans, _, terminated, err := makeargv("", false)
+	if err != nil || len(args) != 0 || len(spans) != 0 || !terminated {
+		t.Errorf("makeargv(\"\") = %v, spans=%v, terminated=%v, err=%v", args, spans, terminated, err)
+	}
+	args, spans, _, terminated, err = makeargv("   \t", false)
+	if err != nil || len(args) != 0 || !terminated {
+		t.Errorf("makeargv(whitespace) = %v, err=%v", args, err)
+	}
+}
+
+func TestMakeargvSimple(t *testing.T) {
+	args, spans, _, _, err := makeargv("ls -la", false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(args) != 2 || args[0] != "ls" || args[1] != "-la" {
+		t.Errorf("got %v, want [ls -la]", args)
+	}
+	if len(spans) != 2 || spans[0] != [2]int{0, 2} || spans[1] != [2]int{3, 6} {
+		t.Errorf("spans = %v, want [[0,2] [3,6]]", spans)
+	}
+}
+
+func TestMakeargvLeadingTrailingSpaces(t *testing.T) {
+	args, _, _, _, err := makeargv("  get   file.txt  ", false)
+	if err != nil || len(args) != 2 || args[0] != "get" || args[1] != "file.txt" {
+		t.Errorf("got %v, want [get file.txt]", args)
+	}
+}
+
+func TestMakeargvSingleQuote(t *testing.T) {
+	args, _, _, _, err := makeargv("get 'Downloads/Test File.txt'", false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(args) != 2 || args[1] != "Downloads/Test File.txt" {
+		t.Errorf("got %v, want [get Downloads/Test File.txt]", args)
+	}
+}
+
+func TestMakeargvDoubleQuote(t *testing.T) {
+	args, _, _, _, err := makeargv(`get "a b"`, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(args) != 2 || args[1] != "a b" {
+		t.Errorf("got %v, want [get a b]", args)
+	}
+}
+
+func TestMakeargvBackslashEscape(t *testing.T) {
+	args, _, _, _, err := makeargv("put Test\\ File\\ With\\ Space.txt", false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(args) != 2 || args[1] != "Test File With Space.txt" {
+		t.Errorf("got %v, want [put Test File With Space.txt]", args)
+	}
+}
+
+func TestMakeargvBackslashPreservesGlobMetachar(t *testing.T) {
+	// Outside quotes, \?, \[, \*, \\ are preserved so glob can undo them.
+	cases := []struct {
+		input string
+		want  string
+	}{
+		{`foo\*`, `foo\*`},
+		{`foo\?`, `foo\?`},
+		{`foo\[`, `foo\[`},
+		{`foo\\`, `foo\\`},
+		{`foo\ bar`, `foo bar`}, // \space → space (unescaped)
+		{`foo\#bar`, `foo#bar`}, // \# → # (unescaped)
+		{`foo\a`, `fooa`},       // \a → a (unescaped)
+	}
+	for _, c := range cases {
+		args, _, _, _, err := makeargv("ls "+c.input, false)
+		if err != nil {
+			t.Errorf("makeargv(ls %s) error: %v", c.input, err)
+			continue
+		}
+		if len(args) != 2 || args[1] != c.want {
+			t.Errorf("makeargv(ls %s) = %q, want %q", c.input, args[1], c.want)
+		}
+	}
+}
+
+func TestMakeargvQuotedGlobMetachar(t *testing.T) {
+	// Inside quotes, glob metacharacters are escaped so they are matched literally.
+	cases := []struct {
+		input string
+		want  string
+	}{
+		{`'foo*'`, `foo\*`},
+		{`"foo?"`, `foo\?`},
+		{`'foo['`, `foo\[`},
+		{`"*"`, `\*`},
+	}
+	for _, c := range cases {
+		args, _, _, _, err := makeargv("ls "+c.input, false)
+		if err != nil {
+			t.Errorf("makeargv(ls %s) error: %v", c.input, err)
+			continue
+		}
+		if len(args) != 2 || args[1] != c.want {
+			t.Errorf("makeargv(ls %s) = %q, want %q", c.input, args[1], c.want)
+		}
+	}
+}
+
+func TestMakeargvQuotedBackslash(t *testing.T) {
+	// Inside quotes, backslash preserves the next character.
+	args, _, _, _, err := makeargv(`ls 'a\ b'`, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(args) != 2 || args[1] != `a\ b` {
+		t.Errorf("got %q, want %q", args[1], `a\ b`)
+	}
+
+	// Inside double quotes, backslash preserves the next character too.
+	args, _, _, _, err = makeargv(`ls "a\ b"`, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(args) != 2 || args[1] != `a\ b` {
+		t.Errorf("got %q, want %q", args[1], `a\ b`)
+	}
+}
+
+func TestMakeargvQuotedEscapeQuote(t *testing.T) {
+	// Inside single quotes, \' → '
+	args, _, _, _, err := makeargv(`ls 'a\'b'`, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(args) != 2 || args[1] != `a'b` {
+		t.Errorf("got %q, want %q", args[1], `a'b`)
+	}
+
+	// Inside double quotes, \" → "
+	args, _, _, _, err = makeargv(`ls "a\"b"`, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(args) != 2 || args[1] != `a"b` {
+		t.Errorf("got %q, want %q", args[1], `a"b`)
+	}
+}
+
+func TestMakeargvAdjacentQuotedSegments(t *testing.T) {
+	args, _, _, _, err := makeargv(`ls 'a''b'`, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(args) != 2 || args[1] != "ab" {
+		t.Errorf("got %q, want %q", args[1], "ab")
+	}
+}
+
+func TestMakeargvQuotedAndUnquotedAdjacent(t *testing.T) {
+	args, _, _, _, err := makeargv(`ls 'a b'c`, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(args) != 2 || args[1] != "a bc" {
+		t.Errorf("got %q, want %q", args[1], "a bc")
+	}
+}
+
+func TestMakeargvMismatchedQuote(t *testing.T) {
+	// A single quote inside double quotes is literal.
+	args, _, _, _, err := makeargv(`ls "a'b"`, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(args) != 2 || args[1] != `a'b` {
+		t.Errorf("got %q, want %q", args[1], `a'b`)
+	}
+	// A double quote inside single quotes is literal.
+	args, _, _, _, err = makeargv(`ls 'a"b'`, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(args) != 2 || args[1] != `a"b` {
+		t.Errorf("got %q, want %q", args[1], `a"b`)
+	}
+}
+
+func TestMakeargvComment(t *testing.T) {
+	args, _, _, _, err := makeargv("ls foo # this is a comment", false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(args) != 2 || args[0] != "ls" || args[1] != "foo" {
+		t.Errorf("got %v, want [ls foo]", args)
+	}
+
+	// A '#' inside quotes is literal.
+	args, _, _, _, err = makeargv("get '#file'", false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(args) != 2 || args[1] != "#file" {
+		t.Errorf("got %v, want [get #file]", args)
+	}
+}
+
+func TestMakeargvUnterminatedQuote(t *testing.T) {
+	_, _, _, _, err := makeargv("get 'foo", false)
+	if err == nil {
+		t.Error("expected error for unterminated quote, got nil")
+	}
+}
+
+func TestMakeargvSloppyUnterminated(t *testing.T) {
+	args, spans, lastquote, terminated, err := makeargv("get 'foo", true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(args) != 2 || args[1] != "foo" {
+		t.Errorf("got %v, want [get foo]", args)
+	}
+	if lastquote != '\'' {
+		t.Errorf("lastquote = %q, want '", lastquote)
+	}
+	if terminated {
+		t.Error("terminated = true, want false")
+	}
+	_ = spans
+}
+
+func TestMakeargvSloppyTrailingBackslash(t *testing.T) {
+	args, _, _, terminated, err := makeargv("get foo\\", true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(args) != 2 || args[1] != "foo" {
+		t.Errorf("got %v, want [get foo]", args)
+	}
+	if terminated {
+		t.Error("terminated = true, want false")
+	}
+}
+
+func TestMakeargvStrictTrailingBackslash(t *testing.T) {
+	_, _, _, _, err := makeargv("get foo\\", false)
+	if err == nil {
+		t.Error("expected error for trailing backslash, got nil")
+	}
+}
+
+func TestMakeargvSpans(t *testing.T) {
+	args, spans, _, _, err := makeargv("cd 'a b' x", false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(args) != 3 || args[1] != "a b" || args[2] != "x" {
+		t.Errorf("args = %v", args)
+	}
+	// cd: [0,2), 'a b': [3,8), x: [9,10)
+	if len(spans) != 3 {
+		t.Fatalf("spans = %v, want 3 entries", spans)
+	}
+	if spans[0] != [2]int{0, 2} {
+		t.Errorf("span[0] = %v, want [0,2]", spans[0])
+	}
+	if spans[1] != [2]int{3, 8} {
+		t.Errorf("span[1] = %v, want [3,8]", spans[1])
+	}
+	if spans[2] != [2]int{9, 10} {
+		t.Errorf("span[2] = %v, want [9,10]", spans[2])
+	}
+}
+
+func TestUndoGlobEscape(t *testing.T) {
+	cases := []struct {
+		input string
+		want  string
+	}{
+		{"foo", "foo"},
+		{`foo\*bar`, `foo*bar`},
+		{`foo\?bar`, `foo?bar`},
+		{`foo\[bar`, `foo[bar`},
+		{`foo\\bar`, `foo\bar`},
+		{`foo\bar`, `foo\bar`},   // \b is not a glob metachar → kept
+		{`foo\ bar`, `foo\ bar`}, // \space kept
+		{`foo\`, `foo\`},         // trailing backslash kept
+	}
+	for _, c := range cases {
+		got := undoGlobEscape(c.input)
+		if got != c.want {
+			t.Errorf("undoGlobEscape(%q) = %q, want %q", c.input, got, c.want)
+		}
+	}
+}
+
+func TestUnescape(t *testing.T) {
+	cases := []struct {
+		input string
+		want  string
+	}{
+		{"foo", "foo"},
+		{`foo\ bar`, `foo bar`},
+		{`foo\*bar`, `foo*bar`},
+		{`foo\\bar`, `foo\bar`},
+		{`foo\bar`, `foobar`}, // \b → b (all backslashes removed)
+		{`foo\\\*`, `foo\*`},  // \\ → \, \* → *
+		{`foo\`, `foo`},       // trailing backslash: removed
+	}
+	for _, c := range cases {
+		got := unescape(c.input)
+		if got != c.want {
+			t.Errorf("unescape(%q) = %q, want %q", c.input, got, c.want)
+		}
+	}
+}
+
+func TestEscapePath(t *testing.T) {
+	cases := []struct {
+		input string
+		quote byte
+		want  string
+	}{
+		{"foo.txt", 0, "foo.txt"},
+		{"a b.txt", 0, `a\ b.txt`},
+		{"a*b.txt", 0, `a\*b.txt`},
+		{"a?b.txt", 0, `a\?b.txt`},
+		{"a[b.txt", 0, `a\[b.txt`},
+		{"a'b.txt", 0, `a\'b.txt`},
+		{`a\b.txt`, 0, `a\\b.txt`},
+		{"a#b.txt", 0, `a\#b.txt`},
+		// Inside quotes, only the quote char and backslash are escaped.
+		{"a b.txt", '\'', "a b.txt"},
+		{"a'b.txt", '\'', `a\'b.txt`},
+		{`a\b.txt`, '\'', `a\\b.txt`},
+		{"a b.txt", '"', "a b.txt"},
+		{"a\"b.txt", '"', `a\"b.txt`},
+		{`a\b.txt`, '"', `a\\b.txt`},
+	}
+	for _, c := range cases {
+		got := escapePath(c.input, c.quote)
+		if got != c.want {
+			t.Errorf("escapePath(%q, %q) = %q, want %q",
+				c.input, c.quote, got, c.want)
+		}
+	}
+}
+
+func TestGlobSplitEscaped(t *testing.T) {
+	// These test cases are added to the existing TestGlobSplit suite.
+	cases := []struct {
+		arg         string
+		wantDir     string
+		wantPattern string
+		wantOK      bool
+	}{
+		// Escaped metacharacters: not globs.
+		{`foo\*`, "", "", false},
+		{`foo\?`, "", "", false},
+		{`foo\[`, "", "", false},
+		{`dir/foo\*`, "", "", false},
+		{`foo\\`, "", "", false},
+		// Unescaped metacharacters: globs.
+		{"foo*", "", "foo*", true},
+		{"dir/foo*", "dir", "foo*", true},
+		{`dir\ one/foo*`, `dir\ one`, "foo*", true},
+		// Empty.
+		{"", "", "", false},
+		// Plain.
+		{"plain", "", "", false},
+		{"path/plain", "", "", false},
+	}
+	for _, c := range cases {
+		dir, pat, ok := globSplit(c.arg)
+		if dir != c.wantDir || pat != c.wantPattern || ok != c.wantOK {
+			t.Errorf("globSplit(%q) = (%q, %q, %v), want (%q, %q, %v)",
+				c.arg, dir, pat, ok, c.wantDir, c.wantPattern, c.wantOK)
+		}
+	}
+}
+
+// TestMakeargvWithPoundInCommentPosition verifies that # outside quotes
+// terminates the line, even when preceded by a backslash-escaped #.
+func TestMakeargvEscapedPound(t *testing.T) {
+	// \# outside quotes produces a literal #, then the # char is consumed
+	// by the escape processing, so it does NOT start a comment. The next
+	// character after the escape is processed normally.
+	args, _, _, _, err := makeargv("ls foo\\#bar", false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(args) != 2 || args[1] != "foo#bar" {
+		t.Errorf("got %v, want [ls foo#bar]", args)
+	}
+}
+
+// TestMakeargvDoubleEscapedGlob verifies that inside quotes, a backslash
+// before a glob metacharacter produces a triple-escaped sequence
+// (\\ + \ + char → \\\* etc.) that glob(3) will undo to a literal.
+func TestMakeargvQuotedBackslashGlob(t *testing.T) {
+	// Inside double quotes, \* → \\\* (triple escaped)
+	args, _, _, _, err := makeargv(`ls "a\*b"`, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if args[1] != `a\\\*b` {
+		t.Errorf("got %q, want %q", args[1], `a\\\*b`)
+	}
+
+	// Inside single quotes, \* → \\\* (same)
+	args, _, _, _, err = makeargv(`ls 'a\*b'`, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if args[1] != `a\\\*b` {
+		t.Errorf("got %q, want %q", args[1], `a\\\*b`)
+	}
+}
+
+// TestMakeargvErrorIsExported ensures the error message matches OpenSSH.
+func TestMakeargvErrorMessage(t *testing.T) {
+	_, _, _, _, err := makeargv("get 'foo", false)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if err.Error() != "unterminated quoted argument" {
+		t.Errorf("got error %q, want 'unterminated quoted argument'", err)
+	}
+}
+
+// TestMakeargvBackslashInUnquotedPreservesDoubleBackslash verifies that
+// outside quotes, \\ is preserved (so glob can undo it to \).
+func TestMakeargvUnquotedDoubleBackslash(t *testing.T) {
+	args, _, _, _, err := makeargv(`ls a\\b`, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if args[1] != `a\\b` {
+		t.Errorf("got %q, want %q", args[1], `a\\b`)
+	}
+}
+
+// TestMakeargvLastquoteAndTerminated verifies lastquote and terminated.
+func TestMakeargvLastquoteTerminated(t *testing.T) {
+	// Unquoted arg: lastquote = 0, terminated = true
+	_, _, lq, term, err := makeargv("ls foo", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if lq != 0 || !term {
+		t.Errorf("lastquote=%d, terminated=%v, want 0, true", lq, term)
+	}
+
+	// Single-quoted and closed: lastquote = ', terminated = true
+	_, _, lq, term, err = makeargv("ls 'foo'", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if lq != '\'' || !term {
+		t.Errorf("lastquote=%d, terminated=%v, want %d, true", lq, term, '\'')
+	}
+
+	// Double-quoted and closed: lastquote = ", terminated = true
+	_, _, lq, term, err = makeargv(`ls "foo"`, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if lq != '"' || !term {
+		t.Errorf("lastquote=%d, terminated=%v, want %d, true", lq, term, '"')
+	}
+}
+
+// TestMakeargvErrorType ensures the error can be compared with errors.Is.
+func TestMakeargvErrorType(t *testing.T) {
+	_, _, _, _, err := makeargv("get 'foo", false)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !errors.Is(err, errUnterminated) {
+		t.Errorf("errors.Is(err, errUnterminated) = false, want true")
+	}
+}
+
+// TestClientDoLsEscapedLiteralGlob verifies that a backslash-escaped glob
+// metacharacter is not treated as a glob: ls foo\* lists the literal path
+// "foo*" (after makeargv, the escaped star reaches doLs as "foo\*").
+func TestClientDoLsEscapedLiteralGlob(t *testing.T) {
+	ch := newMockChannel(makeJSONDataMsg(&Response{
+		OK:      true,
+		Entries: lsEntries("inside"),
+	}))
+	// parts simulate the output of makeargv("ls foo\\*").
+	if err := doLs(ch, "/remote", []string{"ls", `foo\*`}); err != nil {
+		t.Fatalf("doLs error: %v", err)
+	}
+	var got Request
+	if len(ch.Writes) != 1 {
+		t.Fatalf("expected 1 request, got %d", len(ch.Writes))
+	}
+	if err := json.Unmarshal(ch.Writes[0], &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.Cmd != "ls" || got.Path != "/remote/foo*" {
+		t.Fatalf("expected ls /remote/foo*, got %s %q", got.Cmd, got.Path)
+	}
+}
+
+// TestClientDoLsEscapedSpaceInDir verifies that an escaped space inside a glob
+// directory is un-escaped before the ls request: ls 'sub\ dir'/*.txt lists
+// /remote/sub dir and matches entries against *.txt.
+func TestClientDoLsEscapedSpaceInDir(t *testing.T) {
+	ch := newMockChannel(makeJSONDataMsg(&Response{
+		OK:      true,
+		Entries: lsEntries("a.txt", "b.txt", "c.md"),
+	}))
+	// parts simulate the output of makeargv("ls 'sub\\ dir'/*.txt").
+	if err := doLs(ch, "/remote", []string{"ls", `sub\ dir/*.txt`}); err != nil {
+		t.Fatalf("doLs error: %v", err)
+	}
+	var got Request
+	if len(ch.Writes) != 1 {
+		t.Fatalf("expected 1 request, got %d", len(ch.Writes))
+	}
+	if err := json.Unmarshal(ch.Writes[0], &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.Cmd != "ls" || got.Path != "/remote/sub dir" {
+		t.Fatalf("expected ls /remote/sub dir, got %s %q", got.Cmd, got.Path)
+	}
+}
+
+// TestClientDoLsQuotedWildcard verifies that a wildcard inside quotes is
+// escaped to a literal: ls 'test*' must not glob, so the request goes to the
+// literal path /remote/test*.
+func TestClientDoLsQuotedWildcard(t *testing.T) {
+	ch := newMockChannel(makeJSONDataMsg(&Response{
+		OK:      true,
+		Entries: lsEntries("inside"),
+	}))
+	// parts simulate the output of makeargv("ls 'test*'").
+	if err := doLs(ch, "/remote", []string{"ls", `test\*`}); err != nil {
+		t.Fatalf("doLs error: %v", err)
+	}
+	var got Request
+	if len(ch.Writes) != 1 {
+		t.Fatalf("expected 1 request, got %d", len(ch.Writes))
+	}
+	if err := json.Unmarshal(ch.Writes[0], &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.Cmd != "ls" || got.Path != "/remote/test*" {
+		t.Fatalf("expected ls /remote/test*, got %s %q", got.Cmd, got.Path)
+	}
+}
+
+// TestClientDoGetQuotedPath verifies the canonical example:
+// get 'Downloads/Test File.txt' stats the file with the space in its name.
+func TestClientDoGetQuotedPath(t *testing.T) {
+	localDir := t.TempDir()
+	ch := newMockChannel(
+		makeJSONDataMsg(&Response{OK: true, Info: &FileInfo{Name: "Test File.txt", Size: 5}}),
+		makeJSONDataMsg(&Response{OK: true, Data: []byte("hello")}),
+		makeJSONDataMsg(&Response{OK: true, Data: []byte{}}),
+	)
+	// parts simulate the output of makeargv("get 'Downloads/Test File.txt'").
+	if err := doGet(ch, localDir, "/remote", []string{"get", "Downloads/Test File.txt"}); err != nil {
+		t.Fatalf("doGet error: %v", err)
+	}
+	var got Request
+	if len(ch.Writes) != 3 {
+		t.Fatalf("expected 3 requests, got %d", len(ch.Writes))
+	}
+	if err := json.Unmarshal(ch.Writes[0], &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.Cmd != "stat" || got.Path != "/remote/Downloads/Test File.txt" {
+		t.Fatalf("expected stat /remote/Downloads/Test File.txt, got %s %q", got.Cmd, got.Path)
+	}
+	content, err := os.ReadFile(filepath.Join(localDir, "Test File.txt"))
+	if err != nil {
+		t.Fatalf("read downloaded file: %v", err)
+	}
+	if string(content) != "hello" {
+		t.Fatalf("unexpected content: %q", content)
+	}
+}
+
+// TestClientDoGetEscapedGlobMetachar verifies that an escaped glob
+// metacharacter in a get source downloads the literal file:
+// get 'foo*.txt' (quoted) reaches doGet as "foo\*.txt" and is downloaded
+// without globbing.
+func TestClientDoGetEscapedGlobMetachar(t *testing.T) {
+	localDir := t.TempDir()
+	ch := newMockChannel(
+		makeJSONDataMsg(&Response{OK: true, Info: &FileInfo{Name: "foo*.txt", Size: 5}}),
+		makeJSONDataMsg(&Response{OK: true, Data: []byte("hello")}),
+		makeJSONDataMsg(&Response{OK: true, Data: []byte{}}),
+	)
+	// parts simulate the output of makeargv("get 'foo*.txt'").
+	if err := doGet(ch, localDir, "/remote", []string{"get", `foo\*.txt`}); err != nil {
+		t.Fatalf("doGet error: %v", err)
+	}
+	var got Request
+	if len(ch.Writes) != 3 {
+		t.Fatalf("expected 3 requests, got %d", len(ch.Writes))
+	}
+	if err := json.Unmarshal(ch.Writes[0], &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.Cmd != "stat" || got.Path != "/remote/foo*.txt" {
+		t.Fatalf("expected stat /remote/foo*.txt, got %s %q", got.Cmd, got.Path)
+	}
+	content, err := os.ReadFile(filepath.Join(localDir, "foo*.txt"))
+	if err != nil {
+		t.Fatalf("read downloaded file: %v", err)
+	}
+	if string(content) != "hello" {
+		t.Fatalf("unexpected content: %q", content)
+	}
+}
+
+// TestCompleterQuotedWord verifies tab completion inside a single-quoted
+// word: the candidate is re-quoted (opening and closing quote) and the
+// replacement starts at the opening quote.
+func TestCompleterQuotedWord(t *testing.T) {
+	ch := newMockChannel(makeJSONDataMsg(&Response{OK: true, Entries: remoteEntries(
+		FileInfo{Name: "remote.txt"},
+	)}))
+	localDir, remoteDir := "/local", "/remote"
+	c := newCompleter(ch, &localDir, &remoteDir)
+
+	cands, start := c([]rune("get 'rem"), 8)
+	if start != 4 {
+		t.Errorf("start = %d, want 4 (the opening quote)", start)
+	}
+	if len(cands) != 1 || cands[0] != "'remote.txt'" {
+		t.Errorf("candidates = %v, want ['remote.txt']", cands)
+	}
+}
+
+// TestCompleterQuotedWordWithSpace verifies completion inside a quoted word
+// containing a space: the directory is resolved from the parsed word and the
+// candidate is wrapped in quotes.
+func TestCompleterQuotedWordWithSpace(t *testing.T) {
+	ch := newMockChannel(makeJSONDataMsg(&Response{OK: true, Entries: remoteEntries(
+		FileInfo{Name: "foobar.txt"},
+	)}))
+	localDir, remoteDir := "/local", "/remote"
+	c := newCompleter(ch, &localDir, &remoteDir)
+
+	cands, start := c([]rune("cd 'my dir/fo"), 13)
+	if start != 3 {
+		t.Errorf("start = %d, want 3 (the opening quote)", start)
+	}
+	if len(cands) != 1 || cands[0] != "'my dir/foobar.txt'" {
+		t.Errorf("candidates = %v, want ['my dir/foobar.txt']", cands)
+	}
+	var got Request
+	if err := json.Unmarshal(ch.Writes[0], &got); err != nil {
+		t.Fatalf("unmarshal request: %v", err)
+	}
+	if got.Cmd != "ls" || got.Path != "/remote/my dir" {
+		t.Errorf("request = %s %q, want ls %q", got.Cmd, got.Path, "/remote/my dir")
+	}
+}
+
+// TestCompleterQuotedWordSpecialChars verifies that special characters in
+// completions are escaped for unquoted input and left bare inside quotes.
+func TestCompleterQuotedWordSpecialChars(t *testing.T) {
+	// Local completion for lls: files with spaces, quotes and asterisks.
+	dir := t.TempDir()
+	for _, name := range []string{"a b.txt", "it's.txt", "a*b.txt"} {
+		if err := os.WriteFile(filepath.Join(dir, name), nil, 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	localDir, remoteDir := dir, "/remote"
+	c := newCompleter(nil, &localDir, &remoteDir)
+
+	// Unquoted completion escapes the space, quote and star.
+	cands, start := c([]rune("lls "), 4)
+	if start != 4 {
+		t.Errorf("start = %d, want 4", start)
+	}
+	if len(cands) != 3 {
+		t.Fatalf("candidates = %v, want 3", cands)
+	}
+	found := map[string]bool{}
+	for _, cand := range cands {
+		found[cand] = true
+	}
+	for _, want := range []string{`a\ b.txt`, `it\'s.txt`, `a\*b.txt`} {
+		if !found[want] {
+			t.Errorf("missing escaped candidate %q in %v", want, cands)
+		}
+	}
+
+	// Quoted completion leaves spaces and stars bare, escapes quotes.
+	cands, _ = c([]rune("lls '"), 5)
+	if len(cands) != 3 {
+		t.Fatalf("quoted candidates = %v, want 3", cands)
+	}
+	found = map[string]bool{}
+	for _, cand := range cands {
+		found[cand] = true
+	}
+	for _, want := range []string{`'a b.txt'`, `'it\'s.txt'`, `'a*b.txt'`} {
+		if !found[want] {
+			t.Errorf("missing quoted candidate %q in %v", want, cands)
+		}
+	}
+}
+
+// TestMakeargvRoundTripPutExample verifies the second canonical example:
+// put Test\ File\ With\ Space.txt parses to a single path with spaces.
+func TestMakeargvRoundTripPutExample(t *testing.T) {
+	args, _, _, _, err := makeargv("put Test\\ File\\ With\\ Space.txt", false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(args) != 2 || args[1] != "Test File With Space.txt" {
+		t.Errorf("got %v, want [put Test File With Space.txt]", args)
+	}
+}
+
+// TestParseTransferArgsQuoted verifies parseTransferArgs on makeargv output.
+func TestParseTransferArgsQuoted(t *testing.T) {
+	recursive, source, target, err := parseTransferArgs(
+		[]string{"get", "Downloads/Test File.txt", "local copy.txt"}, "get")
+	if err != nil {
+		t.Fatalf("parseTransferArgs error: %v", err)
+	}
+	if recursive || source != "Downloads/Test File.txt" || target != "local copy.txt" {
+		t.Errorf("got (%v, %q, %q)", recursive, source, target)
+	}
+}
+
+// TestCompleterUTF8Spans verifies that completion start offsets are rune
+// indices even when the prefix contains multibyte characters.
+func TestCompleterUTF8Spans(t *testing.T) {
+	ch := newMockChannel(makeJSONDataMsg(&Response{OK: true, Entries: remoteEntries(
+		FileInfo{Name: "café.txt"},
+	)}))
+	localDir, remoteDir := "/local", "/remote"
+	c := newCompleter(ch, &localDir, &remoteDir)
+
+	// "cd docé/ca" — the first argument starts at rune index 3.
+	buf := []rune("cd docé/ca")
+	cands, start := c(buf, len(buf))
+	if start != 3 {
+		t.Errorf("start = %d, want 3", start)
+	}
+	if len(cands) != 1 || cands[0] != "docé/café.txt" {
+		t.Errorf("candidates = %v, want [docé/café.txt]", cands)
+	}
+	var got Request
+	if err := json.Unmarshal(ch.Writes[0], &got); err != nil {
+		t.Fatalf("unmarshal request: %v", err)
+	}
+	if got.Path != "/remote/docé" {
+		t.Errorf("request path = %q, want %q", got.Path, "/remote/docé")
+	}
+}
+
+// TestCommandLineCaseInsensitive verifies the command switch is
+// case-insensitive like OpenSSH.
+func TestCommandNameLowercased(t *testing.T) {
+	if strings.ToLower("GET") != "get" || strings.ToLower("Cd") != "cd" {
+		t.Fatal("strings.ToLower not working as expected")
+	}
+}


### PR DESCRIPTION
Parse interactive commands with the same quoting rules as the OpenSSH sftp client (makeargv): single and double quotes protect whitespace and metacharacters, backslash escapes the next character, and '#' starts a comment. Glob metacharacters keep their escaping for globbed commands (ls, get source) so path.Match can undo it; non-globbed paths are un-escaped (undoGlobEscape/unescape). globSplit is now escape-aware.

Tab completion parses the line up to the cursor with sloppy mode, completes the unescaped word, and re-renders candidates in typed form: special characters are backslash-escaped when unquoted, left bare inside quotes, and open quotes are closed.

Adds unit and integration tests for parsing, escaping, glob handling and quoted tab completion.