### PR TITLE
feat: show transfer progress (percentage and speed) for sftp/scp oper…

### DIFF
--- a/sftp/client.go
+++ b/sftp/client.go
@@ -730,6 +730,7 @@ func downloadFileContents(channel ssh3.Channel, remotePath, localPath string, to
 		prog.add(int64(n))
 	}
 	prog.finish()
+	fmt.Printf("Downloaded %s to %s (%d bytes)\n", remotePath, localPath, offset)
 	done = true
 	return nil
 }
@@ -973,6 +974,7 @@ func uploadFile(channel ssh3.Channel, localPath, remotePath string) error {
 		}
 	}
 	prog.finish()
+	fmt.Printf("Uploaded %s to %s (%d bytes)\n", localPath, remotePath, offset)
 	done = true
 	return nil
 }

--- a/sftp/client.go
+++ b/sftp/client.go
@@ -672,17 +672,26 @@ func downloadRecursive(channel ssh3.Channel, remotePath, localPath string) error
 				if err := downloadRecursive(channel, childRemote, childLocal); err != nil {
 					return err
 				}
-			} else if err := downloadFileContents(channel, childRemote, childLocal, nil); err != nil {
+			} else if err := downloadFileContents(channel, childRemote, childLocal, entry.Size); err != nil {
 				return err
 			}
 		}
 		return nil
 	}
 
-	return downloadFileContents(channel, remotePath, localPath, statResp.Info)
+	var total int64
+	if statResp.Info != nil {
+		total = statResp.Info.Size
+	}
+	return downloadFileContents(channel, remotePath, localPath, total)
 }
 
-func downloadFileContents(channel ssh3.Channel, remotePath, localPath string, info *FileInfo) error {
+// downloadFileContents downloads remotePath into localPath, displaying a
+// per-file progress line (percentage and speed) as the transfer proceeds.
+// total is the remote file size in bytes; 0 when it is unknown, in which case
+// the progress line shows the transferred bytes and speed without a
+// percentage.
+func downloadFileContents(channel ssh3.Channel, remotePath, localPath string, total int64) error {
 	if err := os.MkdirAll(filepath.Dir(localPath), 0o755); err != nil {
 		return err
 	}
@@ -692,6 +701,14 @@ func downloadFileContents(channel ssh3.Channel, remotePath, localPath string, in
 		return err
 	}
 	defer f.Close()
+
+	prog := newProgress(filepath.Base(remotePath), total, os.Stdout)
+	done := false
+	defer func() {
+		if !done {
+			prog.abort()
+		}
+	}()
 
 	var offset int64
 	for {
@@ -710,8 +727,10 @@ func downloadFileContents(channel ssh3.Channel, remotePath, localPath string, in
 			return err
 		}
 		offset += int64(n)
+		prog.add(int64(n))
 	}
-	fmt.Printf("Downloaded %s to %s (%d bytes)\n", remotePath, localPath, offset)
+	prog.finish()
+	done = true
 	return nil
 }
 
@@ -901,7 +920,11 @@ func downloadFile(channel ssh3.Channel, remotePath, localPath string) error {
 		return fmt.Errorf("cannot download a directory")
 	}
 
-	return downloadFileContents(channel, remotePath, localPath, statResp.Info)
+	var total int64
+	if statResp.Info != nil {
+		total = statResp.Info.Size
+	}
+	return downloadFileContents(channel, remotePath, localPath, total)
 }
 
 func uploadFile(channel ssh3.Channel, localPath, remotePath string) error {
@@ -919,6 +942,14 @@ func uploadFile(channel ssh3.Channel, localPath, remotePath string) error {
 		return fmt.Errorf("cannot upload a directory")
 	}
 
+	prog := newProgress(filepath.Base(localPath), info.Size(), os.Stdout)
+	done := false
+	defer func() {
+		if !done {
+			prog.abort()
+		}
+	}()
+
 	var offset int64
 	buf := make([]byte, ChunkSize)
 	for {
@@ -935,11 +966,13 @@ func uploadFile(channel ssh3.Channel, localPath, remotePath string) error {
 				return fmt.Errorf("%s", resp.Error)
 			}
 			offset += int64(n)
+			prog.add(int64(n))
 		}
 		if err == io.EOF {
 			break
 		}
 	}
-	fmt.Printf("Uploaded %s to %s (%d bytes)\n", localPath, remotePath, offset)
+	prog.finish()
+	done = true
 	return nil
 }

--- a/sftp/progress.go
+++ b/sftp/progress.go
@@ -1,0 +1,158 @@
+package sftp
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+
+	"golang.org/x/term"
+)
+
+// redrawInterval is the minimum time between two in-place redraws of a
+// progress line. Transfers run in chunks far smaller than what can be
+// transferred in this interval, so redraws are rate-limited instead of
+// performed once per chunk.
+const redrawInterval = 100 * time.Millisecond
+
+// progress renders a single-file transfer progress line showing the
+// percentage of the total size already transferred and the transfer speed,
+// e.g. "file.txt:  42% 4.2 MB / 10.0 MB 2.3 MB/s". When out is a terminal the
+// line is redrawn in place with carriage returns; otherwise intermediate
+// redraws are skipped and only the final line is printed.
+type progress struct {
+	name    string
+	total   int64 // 0 when the total size is unknown
+	written int64
+
+	start    time.Time
+	lastDraw time.Time
+	lastLen  int
+	drawn    bool
+	out      io.Writer
+	inplace  bool
+}
+
+// newProgress creates a progress reporter for the transfer of name whose
+// total size is total bytes (0 when unknown). Output is written to out and,
+// when out is a terminal, updated in place with carriage returns.
+func newProgress(name string, total int64, out io.Writer) *progress {
+	inplace := false
+	if f, ok := out.(*os.File); ok {
+		inplace = term.IsTerminal(int(f.Fd()))
+	}
+	return &progress{
+		name:    name,
+		total:   total,
+		start:   time.Now(),
+		out:     out,
+		inplace: inplace,
+	}
+}
+
+// add records that n more bytes have been transferred. For terminal output
+// the progress line is redrawn at most once every redrawInterval; for
+// non-terminal output nothing is drawn until finish.
+func (p *progress) add(n int64) {
+	p.written += n
+	if !p.inplace {
+		return
+	}
+	now := time.Now()
+	if p.lastDraw.IsZero() || now.Sub(p.lastDraw) >= redrawInterval {
+		p.draw(now)
+		p.lastDraw = now
+	}
+}
+
+// finish prints the final progress line, always terminated by a newline so
+// the cursor returns to the start of a fresh line.
+func (p *progress) finish() {
+	p.draw(time.Now())
+	if p.inplace {
+		fmt.Fprint(p.out, "\n")
+	}
+}
+
+// abort clears a partially drawn in-place progress line so a following error
+// message starts on a clean line. It does nothing when nothing was drawn.
+func (p *progress) abort() {
+	if p.inplace && p.drawn {
+		fmt.Fprintf(p.out, "\r%s\r", strings.Repeat(" ", p.lastLen))
+	}
+}
+
+func (p *progress) draw(now time.Time) {
+	line := p.line(now)
+	if !p.inplace {
+		fmt.Fprintf(p.out, "%s\n", line)
+		return
+	}
+	fmt.Fprintf(p.out, "\r%s", line)
+	if len(line) < p.lastLen {
+		// Pad with spaces so a shorter line fully overwrites the previous,
+		// longer one.
+		fmt.Fprintf(p.out, "%s", strings.Repeat(" ", p.lastLen-len(line)))
+	}
+	p.lastLen = len(line)
+	p.drawn = true
+}
+
+func (p *progress) line(now time.Time) string {
+	var b strings.Builder
+	b.WriteString(p.name)
+	b.WriteString(": ")
+
+	if p.total > 0 {
+		pct := float64(p.written) * 100 / float64(p.total)
+		if pct > 100 {
+			pct = 100
+		}
+		fmt.Fprintf(&b, "%3.0f%% %s / %s ", pct, humanBytes(p.written), humanBytes(p.total))
+	} else {
+		b.WriteString(humanBytes(p.written))
+		b.WriteString(" ")
+	}
+
+	elapsed := now.Sub(p.start).Seconds()
+	var speed float64
+	if elapsed > 0 {
+		speed = float64(p.written) / elapsed
+	}
+	b.WriteString(formatSpeed(speed))
+	return b.String()
+}
+
+// humanBytes renders a byte count in a human-readable form using 1024-based
+// units (B, KB, MB, GB, TB, PB), e.g. 1536 -> "1.5 KB".
+func humanBytes(n int64) string {
+	const unit = 1024
+	if n < unit {
+		return fmt.Sprintf("%d B", n)
+	}
+	div, exp := int64(unit), 0
+	for m := n / unit; m >= unit; m /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f %cB", float64(n)/float64(div), "KMGTPE"[exp])
+}
+
+// formatSpeed renders a transfer speed in bytes per second in a
+// human-readable form using 1024-based units, e.g. 2.3e6 -> "2.2 MB/s".
+func formatSpeed(bytesPerSec float64) string {
+	if bytesPerSec < 0 || bytesPerSec != bytesPerSec || bytesPerSec > 1e18 {
+		return "- B/s"
+	}
+	const unit = 1024
+	if bytesPerSec < unit {
+		return fmt.Sprintf("%.0f B/s", bytesPerSec)
+	}
+	div, exp := float64(unit), 0
+	for m := bytesPerSec / unit; m >= unit; m /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f %cB/s", bytesPerSec/div, "KMGTPE"[exp])
+}

--- a/sftp/progress_test.go
+++ b/sftp/progress_test.go
@@ -1,0 +1,164 @@
+package sftp
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestHumanBytes(t *testing.T) {
+	cases := []struct {
+		n    int64
+		want string
+	}{
+		{0, "0 B"},
+		{1, "1 B"},
+		{1023, "1023 B"},
+		{1024, "1.0 KB"},
+		{1536, "1.5 KB"},
+		{1024 * 1024, "1.0 MB"},
+		{5*1024*1024 + 512*1024, "5.5 MB"},
+		{1024 * 1024 * 1024, "1.0 GB"},
+		{int64(3) * 1024 * 1024 * 1024 * 1024, "3.0 TB"},
+	}
+	for _, c := range cases {
+		if got := humanBytes(c.n); got != c.want {
+			t.Errorf("humanBytes(%d) = %q, want %q", c.n, got, c.want)
+		}
+	}
+}
+
+func TestFormatSpeed(t *testing.T) {
+	cases := []struct {
+		spd  float64
+		want string
+	}{
+		{0, "0 B/s"},
+		{512, "512 B/s"},
+		{1024, "1.0 KB/s"},
+		{1536, "1.5 KB/s"},
+		{2.5 * 1024 * 1024, "2.5 MB/s"},
+		{1024 * 1024 * 1024, "1.0 GB/s"},
+	}
+	for _, c := range cases {
+		if got := formatSpeed(c.spd); got != c.want {
+			t.Errorf("formatSpeed(%v) = %q, want %q", c.spd, got, c.want)
+		}
+	}
+
+	// Degenerate inputs must not panic or produce nonsense.
+	for _, bad := range []float64{-1, nanValue(), 1e19} {
+		if got := formatSpeed(bad); !strings.HasSuffix(got, "B/s") {
+			t.Errorf("formatSpeed(%v) = %q, want a speed", bad, got)
+		}
+	}
+}
+
+func nanValue() float64 {
+	var zero float64
+	return zero / zero
+}
+
+func TestProgressNonTerminalPrintsFinalLineOnly(t *testing.T) {
+	var buf bytes.Buffer
+	p := newProgress("file.txt", 1000, &buf)
+	p.add(420)
+	// Non-terminal output: nothing is drawn until finish.
+	if buf.Len() != 0 {
+		t.Fatalf("expected no output before finish, got %q", buf.String())
+	}
+	p.finish()
+	got := buf.String()
+	for _, want := range []string{"file.txt: ", "42%", "420 B", "1000 B", "B/s", "\n"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("finish output %q does not contain %q", got, want)
+		}
+	}
+}
+
+func TestProgressUnknownTotalOmitsPercentage(t *testing.T) {
+	var buf bytes.Buffer
+	p := newProgress("unknown.bin", 0, &buf)
+	p.add(2048)
+	p.finish()
+	got := buf.String()
+	if strings.Contains(got, "%") {
+		t.Errorf("unknown total should not show a percentage, got %q", got)
+	}
+	if !strings.Contains(got, "2.0 KB") {
+		t.Errorf("expected transferred bytes in output, got %q", got)
+	}
+}
+
+func TestProgressInPlaceRedrawThrottled(t *testing.T) {
+	var buf bytes.Buffer
+	p := &progress{name: "big.bin", total: 100, out: &buf, inplace: true, start: time.Now()}
+
+	p.add(25)
+	got := buf.String()
+	if !strings.HasPrefix(got, "\rbig.bin: ") {
+		t.Fatalf("expected in-place redraw, got %q", got)
+	}
+	if strings.Contains(got, "\n") {
+		t.Fatalf("in-place redraw must not contain a newline, got %q", got)
+	}
+
+	// A second add within redrawInterval must not redraw.
+	before := buf.Len()
+	p.add(25)
+	if buf.Len() != before {
+		t.Fatalf("expected throttled redraw, output grew from %d to %d", before, buf.Len())
+	}
+
+	// After the interval a redraw is allowed.
+	time.Sleep(redrawInterval + 20*time.Millisecond)
+	p.add(25)
+	if buf.Len() <= before {
+		t.Fatal("expected a redraw after the throttle interval")
+	}
+	if strings.Count(buf.String(), "\r") != 2 {
+		t.Fatalf("expected exactly 2 redraws, got %q", buf.String())
+	}
+
+	p.finish()
+	got = buf.String()
+	if !strings.HasSuffix(got, "\n") {
+		t.Fatalf("finish must end with a newline, got %q", got)
+	}
+	if !strings.Contains(got, "75%") {
+		t.Fatalf("expected final percentage 75%%, got %q", got)
+	}
+}
+
+func TestProgressFinishCapsAt100Percent(t *testing.T) {
+	var buf bytes.Buffer
+	p := &progress{name: "f", total: 10, written: 20, out: &buf, inplace: true, start: time.Now()}
+	p.finish()
+	if !strings.Contains(buf.String(), "100%") {
+		t.Fatalf("expected percentage capped at 100%%, got %q", buf.String())
+	}
+}
+
+func TestProgressAbortClearsDrawnLine(t *testing.T) {
+	var buf bytes.Buffer
+	p := &progress{name: "f", total: 100, out: &buf, inplace: true, start: time.Now()}
+	p.add(10)
+	p.abort()
+	got := buf.String()
+	if !strings.HasSuffix(got, "\r") {
+		t.Fatalf("abort should end with a carriage return, got %q", got)
+	}
+	if !strings.Contains(got, strings.Repeat(" ", 5)) {
+		t.Fatalf("abort should pad the line with spaces to clear it, got %q", got)
+	}
+}
+
+func TestProgressAbortWithoutDrawDoesNothing(t *testing.T) {
+	var buf bytes.Buffer
+	p := &progress{name: "f", total: 100, out: &buf, inplace: true, start: time.Now()}
+	p.abort()
+	if buf.Len() != 0 {
+		t.Fatalf("abort before any draw should write nothing, got %q", buf.String())
+	}
+}


### PR DESCRIPTION
…ations

Add a progress reporter that renders a per-file progress line with the percentage of the total size transferred and the transfer speed, e.g. 'file.txt:  42% 4.2 MB / 10.0 MB 2.3 MB/s'. On a terminal the line is redrawn in place (rate-limited to one redraw per 100ms); otherwise only the final line is printed. A partial line is cleared on error so messages stay readable.

Wire the reporter into uploadFile and downloadFileContents (with the remote size threaded through downloadFile and downloadRecursive), which are shared by both the interactive SFTP client and the SCP client, so both get progress for single-file and recursive transfers.