### PR TITLE
feat: cancel sftp/scp transfers with Ctrl+C

### DIFF
--- a/cmd/sshoq.go
+++ b/cmd/sshoq.go
@@ -968,6 +968,11 @@ func ClientMain() int {
 		log.Error().Msgf("the process exited with signal %s: %s", sessionError.Signal, sessionError.ErrorMessageUTF8)
 		return -1
 	default:
+		if errors.Is(err, sshoqsftp.ErrCancelled) {
+			// The transfer was interrupted by Ctrl+C: exit like a process
+			// killed by SIGINT (128 + 2) instead of reporting an error.
+			return 130
+		}
 		if err != nil {
 			log.Error().Msgf("an error was encountered when running the session: %s", sessionError)
 			return -1

--- a/sftp/cancel.go
+++ b/sftp/cancel.go
@@ -1,0 +1,58 @@
+package sftp
+
+import (
+	"errors"
+	"os"
+	"os/signal"
+	"sync/atomic"
+	"syscall"
+)
+
+// ErrCancelled is returned by a transfer that was interrupted by the user:
+// Ctrl+C in interactive sftp mode, or SIGINT/SIGTERM in scp mode.
+var ErrCancelled = errors.New("transfer cancelled")
+
+// transferCancel is a cancellation flag shared by a transfer and the input
+// watcher (interactive mode) or signal handler (scp mode) that interrupts it.
+// Transfer loops check cancelled() between chunks and stop as soon as it is
+// set, so a Ctrl+C takes effect at the next chunk boundary at the latest.
+type transferCancel struct {
+	flag atomic.Bool
+}
+
+// cancel marks the transfer as cancelled. It is safe to call more than once
+// and from any goroutine.
+func (c *transferCancel) cancel() {
+	if c != nil {
+		c.flag.Store(true)
+	}
+}
+
+// cancelled reports whether the transfer has been cancelled. A nil receiver
+// reports false, so transfers without a cancel watcher (e.g. in tests) behave
+// exactly as before.
+func (c *transferCancel) cancelled() bool {
+	return c != nil && c.flag.Load()
+}
+
+// watchSignals cancels a transfer when SIGINT or SIGTERM arrives. Scp mode
+// runs with a normal terminal, so Ctrl+C is delivered as SIGINT rather than
+// as a raw byte (unlike interactive mode, where the terminal is raw and the
+// input watcher handles Ctrl+C). It returns a stop function that unregisters
+// the handler and lets a later Ctrl+C take its default action again.
+func watchSignals(cancel *transferCancel) func() {
+	sigs := make(chan os.Signal, 1)
+	stop := make(chan struct{})
+	signal.Notify(sigs, os.Interrupt, syscall.SIGTERM)
+	go func() {
+		select {
+		case <-sigs:
+			cancel.cancel()
+		case <-stop:
+		}
+	}()
+	return func() {
+		signal.Stop(sigs)
+		close(stop)
+	}
+}

--- a/sftp/cancel_test.go
+++ b/sftp/cancel_test.go
@@ -1,0 +1,288 @@
+package sftp
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/creack/pty"
+
+	ssh3 "github.com/h4sh5/sshoq"
+	ssh3Messages "github.com/h4sh5/sshoq/message"
+)
+
+// cancellingChannel wraps a MockChannel and sets cancel the moment a request
+// is written, so a transfer can be interrupted deterministically between
+// chunks (a mock channel answers every request instantly, which would finish
+// the transfer before an async cancel could land).
+type cancellingChannel struct {
+	*ssh3.MockChannel
+	cancel   *transferCancel
+	cancelAt int // cancel when this request (1-based) is written
+	writes   int
+}
+
+func (c *cancellingChannel) WriteData(dataBuf []byte, dataType ssh3Messages.SSHDataType) (int, error) {
+	c.writes++
+	if c.writes == c.cancelAt {
+		c.cancel.cancel()
+	}
+	return c.MockChannel.WriteData(dataBuf, dataType)
+}
+
+// waitFor polls until cond returns true or the deadline expires, failing the
+// test otherwise.
+func waitFor(t *testing.T, what string, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for !cond() {
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for %s", what)
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+}
+
+// --- transfer-level cancellation ---
+
+// TestUploadFileCancelled verifies that an upload interrupted by Ctrl+C stops
+// at the next chunk boundary and returns ErrCancelled without finishing.
+func TestUploadFileCancelled(t *testing.T) {
+	tmp := t.TempDir()
+	localPath := filepath.Join(tmp, "local.bin")
+	os.WriteFile(localPath, bytes.Repeat([]byte("x"), ChunkSize*2), 0644)
+
+	cancel := &transferCancel{}
+	ch := &cancellingChannel{
+		MockChannel: newMockChannel(makeJSONDataMsg(&Response{ID: 1, OK: true})),
+		cancel:      cancel,
+		cancelAt:    1, // interrupt as soon as the first chunk is sent
+	}
+
+	err := uploadFile(ch, localPath, "remote.bin", cancel)
+	if !errors.Is(err, ErrCancelled) {
+		t.Fatalf("expected ErrCancelled, got %v", err)
+	}
+	if len(ch.Writes) != 1 {
+		t.Fatalf("expected the transfer to stop after 1 chunk, got %d", len(ch.Writes))
+	}
+}
+
+// TestUploadFileCancelledBeforeStart verifies that a transfer cancelled before
+// it begins sends no requests at all.
+func TestUploadFileCancelledBeforeStart(t *testing.T) {
+	tmp := t.TempDir()
+	localPath := filepath.Join(tmp, "local.bin")
+	os.WriteFile(localPath, []byte("data"), 0644)
+
+	cancel := &transferCancel{}
+	cancel.cancel()
+	ch := newMockChannel()
+
+	err := uploadFile(ch, localPath, "remote.bin", cancel)
+	if !errors.Is(err, ErrCancelled) {
+		t.Fatalf("expected ErrCancelled, got %v", err)
+	}
+	if len(ch.Writes) != 0 {
+		t.Fatalf("expected no requests when cancelled, got %d", len(ch.Writes))
+	}
+}
+
+// TestDownloadFileCancelled verifies that a download interrupted by Ctrl+C
+// returns ErrCancelled and removes the partially downloaded local file so it
+// is not mistaken for a complete download.
+func TestDownloadFileCancelled(t *testing.T) {
+	tmp := t.TempDir()
+	localPath := filepath.Join(tmp, "out.bin")
+	chunk := bytes.Repeat([]byte("y"), ChunkSize)
+
+	cancel := &transferCancel{}
+	ch := &cancellingChannel{
+		MockChannel: newMockChannel(
+			makeJSONDataMsg(&Response{ID: 1, OK: true, Info: &FileInfo{Name: "remote.bin", Size: int64(ChunkSize * 4)}}),
+			makeJSONDataMsg(&Response{ID: 2, OK: true, Data: chunk}),
+		),
+		cancel:   cancel,
+		cancelAt: 2, // interrupt as soon as the first get request is sent
+	}
+
+	err := downloadFile(ch, "remote.bin", localPath, cancel)
+	if !errors.Is(err, ErrCancelled) {
+		t.Fatalf("expected ErrCancelled, got %v", err)
+	}
+	if _, statErr := os.Stat(localPath); !os.IsNotExist(statErr) {
+		t.Fatalf("partial download should be removed, stat error: %v", statErr)
+	}
+}
+
+// TestDownloadRecursiveCancelled verifies that a cancelled recursive download
+// stops before issuing any request.
+func TestDownloadRecursiveCancelled(t *testing.T) {
+	cancel := &transferCancel{}
+	cancel.cancel()
+	ch := newMockChannel()
+
+	err := downloadRecursive(ch, "remote-dir", filepath.Join(t.TempDir(), "out"), cancel)
+	if !errors.Is(err, ErrCancelled) {
+		t.Fatalf("expected ErrCancelled, got %v", err)
+	}
+	if len(ch.Writes) != 0 {
+		t.Fatalf("expected no requests when cancelled, got %d", len(ch.Writes))
+	}
+}
+
+// TestUploadRecursiveCancelled verifies that a cancelled recursive upload
+// stops before issuing any request.
+func TestUploadRecursiveCancelled(t *testing.T) {
+	tmp := t.TempDir()
+	localDir := filepath.Join(tmp, "src")
+	os.MkdirAll(localDir, 0o755)
+	os.WriteFile(filepath.Join(localDir, "a.txt"), []byte("a"), 0644)
+
+	cancel := &transferCancel{}
+	cancel.cancel()
+	ch := newMockChannel()
+
+	err := uploadRecursive(ch, localDir, "remote-dir", cancel)
+	if !errors.Is(err, ErrCancelled) {
+		t.Fatalf("expected ErrCancelled, got %v", err)
+	}
+	if len(ch.Writes) != 0 {
+		t.Fatalf("expected no requests when cancelled, got %d", len(ch.Writes))
+	}
+}
+
+// --- scp-mode signal handling ---
+
+// TestWatchSignals verifies that SIGTERM delivered to the process cancels the
+// transfer through the signal watcher used by scp mode.
+func TestWatchSignals(t *testing.T) {
+	var cancel transferCancel
+	stop := watchSignals(&cancel)
+	defer stop()
+
+	if err := syscall.Kill(os.Getpid(), syscall.SIGTERM); err != nil {
+		t.Fatal(err)
+	}
+	waitFor(t, "SIGTERM to cancel the transfer", cancel.cancelled)
+}
+
+// --- interactive-mode stdin watcher ---
+
+// newTestPty replaces os.Stdin/os.Stdout with a fresh pty and returns the
+// master end, like the other readline pty tests.
+func newTestPty(t *testing.T) *os.File {
+	t.Helper()
+	ptmx, tty, err := pty.Open()
+	if err != nil {
+		t.Skipf("pty not available: %v", err)
+	}
+	pty.Setsize(ptmx, &pty.Winsize{Rows: 24, Cols: 80})
+	oldIn, oldOut := os.Stdin, os.Stdout
+	os.Stdin, os.Stdout = tty, tty
+	t.Cleanup(func() {
+		os.Stdin, os.Stdout = oldIn, oldOut
+		ptmx.Close()
+		tty.Close()
+	})
+	return ptmx
+}
+
+// startWatcher starts the stdin watcher of r and returns a stop function that
+// stops it and waits for it to exit.
+func startWatcher(r *interactiveReader, cancel *transferCancel) func() {
+	ctx, stop := context.WithCancel(context.Background())
+	r.watchWg.Add(1)
+	go r.watchCancel(ctx, cancel)
+	return func() {
+		stop()
+		r.watchWg.Wait()
+	}
+}
+
+// TestInteractiveReaderWatchCancelCancelsOnCtrlC verifies that pressing
+// Ctrl+C while a transfer runs sets the cancel flag: in raw mode the terminal
+// delivers Ctrl+C as byte 0x03, not as SIGINT.
+func TestInteractiveReaderWatchCancelCancelsOnCtrlC(t *testing.T) {
+	ptmx := newTestPty(t)
+	r, err := newInteractiveReader()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer r.close()
+
+	var cancel transferCancel
+	stop := startWatcher(r, &cancel)
+
+	if _, err := ptmx.Write([]byte{0x03}); err != nil {
+		t.Fatal(err)
+	}
+	waitFor(t, "Ctrl+C to cancel the transfer", cancel.cancelled)
+	stop()
+}
+
+// TestInteractiveReaderWatchCancelBuffersTypedInput verifies that bytes typed
+// while a transfer runs are buffered and reappear at the next prompt instead
+// of being lost to the watcher's read.
+func TestInteractiveReaderWatchCancelBuffersTypedInput(t *testing.T) {
+	ptmx := newTestPty(t)
+	r, err := newInteractiveReader()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer r.close()
+
+	var cancel transferCancel
+	stop := startWatcher(r, &cancel)
+
+	if _, err := ptmx.WriteString("ls\r"); err != nil {
+		t.Fatal(err)
+	}
+	waitFor(t, "typed input to be buffered", func() bool {
+		r.editor.pendingMu.Lock()
+		defer r.editor.pendingMu.Unlock()
+		return len(r.editor.pending) == 3
+	})
+	stop()
+
+	line, err := r.readLine("sftp> ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if line != "ls" {
+		t.Fatalf("expected the buffered line %q at the next prompt, got %q", "ls", line)
+	}
+}
+
+// TestInteractiveReaderWatchCancelStopsOnContext verifies that the watcher
+// exits when the transfer finishes even when no input arrives, so it never
+// steals bytes typed after the transfer.
+func TestInteractiveReaderWatchCancelStopsOnContext(t *testing.T) {
+	ptmx := newTestPty(t)
+	r, err := newInteractiveReader()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer r.close()
+
+	var cancel transferCancel
+	stop := startWatcher(r, &cancel)
+	stop() // no input at all: must still exit promptly
+
+	// Bytes typed after the transfer must reach the next prompt untouched.
+	if _, err := ptmx.WriteString("pwd\r"); err != nil {
+		t.Fatal(err)
+	}
+	line, err := r.readLine("sftp> ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if line != "pwd" {
+		t.Fatalf("expected the line %q at the next prompt, got %q", "pwd", line)
+	}
+}

--- a/sftp/client.go
+++ b/sftp/client.go
@@ -1,6 +1,8 @@
 package sftp
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -141,8 +143,16 @@ func RunInteractiveClient(c *client.Client) error {
 			}
 
 		case "get":
-			if err := doGet(channel, localDir, remoteDir, parts); err != nil {
-				fmt.Fprintf(os.Stderr, "get: %s\n", err)
+			cancel := &transferCancel{}
+			err := input.runTransfer(cancel, func() error {
+				return doGet(channel, localDir, remoteDir, parts, cancel)
+			})
+			if err != nil {
+				if errors.Is(err, ErrCancelled) {
+					fmt.Println("Cancelled")
+				} else {
+					fmt.Fprintf(os.Stderr, "get: %s\n", err)
+				}
 				continue
 			}
 
@@ -166,12 +176,19 @@ func RunInteractiveClient(c *client.Client) error {
 				remoteFile = path.Join(remoteDir, remoteFile)
 			}
 
-			if recursive {
-				if err := uploadRecursive(channel, localFile, remoteFile); err != nil {
+			cancel := &transferCancel{}
+			err = input.runTransfer(cancel, func() error {
+				if recursive {
+					return uploadRecursive(channel, localFile, remoteFile, cancel)
+				}
+				return uploadFile(channel, localFile, remoteFile, cancel)
+			})
+			if err != nil {
+				if errors.Is(err, ErrCancelled) {
+					fmt.Println("Cancelled")
+				} else {
 					fmt.Fprintf(os.Stderr, "put: %s\n", err)
 				}
-			} else if err := uploadFile(channel, localFile, remoteFile); err != nil {
-				fmt.Fprintf(os.Stderr, "put: %s\n", err)
 			}
 
 		case "mkdir":
@@ -490,6 +507,27 @@ func doLs(channel ssh3.Channel, remoteDir string, parts []string) error {
 	return nil
 }
 
+// runTransfer runs fn while making Ctrl+C cancel it. In terminal mode the
+// session's terminal is raw, so Ctrl+C arrives as byte 0x03 on stdin instead
+// of as SIGINT: a watcher goroutine consumes it (buffering any other typed
+// bytes for the next prompt) and sets cancel, which fn's transfer loops check
+// between chunks. With piped input the terminal is not raw, so Ctrl+C is
+// delivered as a signal and a signal handler cancels instead.
+func (r *interactiveReader) runTransfer(cancel *transferCancel, fn func() error) error {
+	if r.editor == nil {
+		stop := watchSignals(cancel)
+		defer stop()
+		return fn()
+	}
+	ctx, stop := context.WithCancel(context.Background())
+	r.watchWg.Add(1)
+	go r.watchCancel(ctx, cancel)
+	err := fn()
+	stop()
+	r.watchWg.Wait()
+	return err
+}
+
 // doGet downloads a remote file or directory, or every entry in the resolved
 // source directory whose name matches a glob pattern. It mirrors doLs: when the
 // remote source contains glob metacharacters in its final path component (*, ?,
@@ -498,7 +536,7 @@ func doLs(channel ssh3.Channel, remoteDir string, parts []string) error {
 // un-globbed source is downloaded directly, preserving the previous behavior.
 // The -r flag is honored in both cases: directories (whether matched by the
 // pattern or named directly) are transferred recursively via downloadOne.
-func doGet(channel ssh3.Channel, localDir, remoteDir string, parts []string) error {
+func doGet(channel ssh3.Channel, localDir, remoteDir string, parts []string, cancel *transferCancel) error {
 	recursive, remoteSource, localTarget, err := parseTransferArgs(parts, "get")
 	if err != nil {
 		return err
@@ -551,7 +589,7 @@ func doGet(channel ssh3.Channel, localDir, remoteDir string, parts []string) err
 			}
 			remoteFile := path.Join(sourceDir, e.Name)
 			localFile := filepath.Join(localDir, filepath.Base(filepath.Clean(remoteFile)))
-			if err := downloadOne(channel, remoteFile, localFile, recursive); err != nil {
+			if err := downloadOne(channel, remoteFile, localFile, recursive, cancel); err != nil {
 				return err
 			}
 		}
@@ -567,18 +605,18 @@ func doGet(channel ssh3.Channel, localDir, remoteDir string, parts []string) err
 		localFile = filepath.Base(filepath.Clean(remoteFile))
 	}
 	localFile = filepath.Join(localDir, localFile)
-	return downloadOne(channel, remoteFile, localFile, recursive)
+	return downloadOne(channel, remoteFile, localFile, recursive, cancel)
 }
 
 // downloadOne downloads remoteFile to localFile, descending into directories when
 // recursive is set. It reproduces the transfer behavior of a non-glob "get" and
 // is shared by the glob and non-glob paths of doGet so that wildcards work the
 // same way with and without -r.
-func downloadOne(channel ssh3.Channel, remoteFile, localFile string, recursive bool) error {
+func downloadOne(channel ssh3.Channel, remoteFile, localFile string, recursive bool, cancel *transferCancel) error {
 	if recursive {
-		return downloadRecursive(channel, remoteFile, localFile)
+		return downloadRecursive(channel, remoteFile, localFile, cancel)
 	}
-	return downloadFile(channel, remoteFile, localFile)
+	return downloadFile(channel, remoteFile, localFile, cancel)
 }
 
 // globSplit reports whether arg contains unescaped glob metacharacters in its
@@ -646,7 +684,10 @@ func parseTransferArgs(parts []string, cmd string) (recursive bool, source strin
 	return recursive, source, target, nil
 }
 
-func downloadRecursive(channel ssh3.Channel, remotePath, localPath string) error {
+func downloadRecursive(channel ssh3.Channel, remotePath, localPath string, cancel *transferCancel) error {
+	if cancel.cancelled() {
+		return ErrCancelled
+	}
 	statResp, err := doRequest(channel, &Request{Cmd: "stat", Path: remotePath})
 	if err != nil {
 		return err
@@ -669,10 +710,10 @@ func downloadRecursive(channel ssh3.Channel, remotePath, localPath string) error
 			childRemote := path.Join(remotePath, entry.Name)
 			childLocal := filepath.Join(localPath, entry.Name)
 			if entry.IsDir {
-				if err := downloadRecursive(channel, childRemote, childLocal); err != nil {
+				if err := downloadRecursive(channel, childRemote, childLocal, cancel); err != nil {
 					return err
 				}
-			} else if err := downloadFileContents(channel, childRemote, childLocal, entry.Size); err != nil {
+			} else if err := downloadFileContents(channel, childRemote, childLocal, entry.Size, cancel); err != nil {
 				return err
 			}
 		}
@@ -683,7 +724,7 @@ func downloadRecursive(channel ssh3.Channel, remotePath, localPath string) error
 	if statResp.Info != nil {
 		total = statResp.Info.Size
 	}
-	return downloadFileContents(channel, remotePath, localPath, total)
+	return downloadFileContents(channel, remotePath, localPath, total, cancel)
 }
 
 // downloadFileContents downloads remotePath into localPath, displaying a
@@ -691,7 +732,7 @@ func downloadRecursive(channel ssh3.Channel, remotePath, localPath string) error
 // total is the remote file size in bytes; 0 when it is unknown, in which case
 // the progress line shows the transferred bytes and speed without a
 // percentage.
-func downloadFileContents(channel ssh3.Channel, remotePath, localPath string, total int64) error {
+func downloadFileContents(channel ssh3.Channel, remotePath, localPath string, total int64, cancel *transferCancel) error {
 	if err := os.MkdirAll(filepath.Dir(localPath), 0o755); err != nil {
 		return err
 	}
@@ -702,7 +743,7 @@ func downloadFileContents(channel ssh3.Channel, remotePath, localPath string, to
 	}
 	defer f.Close()
 
-	prog := newProgress(filepath.Base(remotePath), total, os.Stdout)
+	prog := newProgress(filepath.Base(remotePath), total, os.Stdout, cancel)
 	done := false
 	defer func() {
 		if !done {
@@ -712,6 +753,12 @@ func downloadFileContents(channel ssh3.Channel, remotePath, localPath string, to
 
 	var offset int64
 	for {
+		if prog.cancelled() {
+			// Remove the partially downloaded file so it is not mistaken for
+			// a complete download.
+			os.Remove(localPath)
+			return ErrCancelled
+		}
 		resp, err := doRequest(channel, &Request{Cmd: "get", Path: remotePath, Offset: offset, Limit: ChunkSize})
 		if err != nil {
 			return err
@@ -735,13 +782,16 @@ func downloadFileContents(channel ssh3.Channel, remotePath, localPath string, to
 	return nil
 }
 
-func uploadRecursive(channel ssh3.Channel, localPath, remotePath string) error {
+func uploadRecursive(channel ssh3.Channel, localPath, remotePath string, cancel *transferCancel) error {
+	if cancel.cancelled() {
+		return ErrCancelled
+	}
 	info, err := os.Stat(localPath)
 	if err != nil {
 		return err
 	}
 	if !info.IsDir() {
-		return uploadFile(channel, localPath, remotePath)
+		return uploadFile(channel, localPath, remotePath, cancel)
 	}
 	if err := ensureRemoteDir(channel, remotePath); err != nil {
 		return err
@@ -759,10 +809,10 @@ func uploadRecursive(channel ssh3.Channel, localPath, remotePath string) error {
 			return err
 		}
 		if childInfo.IsDir() {
-			if err := uploadRecursive(channel, childLocal, childRemote); err != nil {
+			if err := uploadRecursive(channel, childLocal, childRemote, cancel); err != nil {
 				return err
 			}
-		} else if err := uploadFile(channel, childLocal, childRemote); err != nil {
+		} else if err := uploadFile(channel, childLocal, childRemote, cancel); err != nil {
 			return err
 		}
 	}
@@ -816,6 +866,8 @@ func printHelp() {
   lls [path]      list local directory
   lpwd            print local working directory
   exit/quit       exit
+
+Ctrl+C during a get/put cancels the transfer and returns to the prompt.
 
 Paths are parsed like OpenSSH sftp: single quotes ('...') and double quotes
 ("...") protect spaces and metacharacters, and a backslash escapes the next
@@ -909,7 +961,7 @@ func doRequest(channel ssh3.Channel, req *Request) (*Response, error) {
 	return ReceiveResponse(channel)
 }
 
-func downloadFile(channel ssh3.Channel, remotePath, localPath string) error {
+func downloadFile(channel ssh3.Channel, remotePath, localPath string, cancel *transferCancel) error {
 	statResp, err := doRequest(channel, &Request{Cmd: "stat", Path: remotePath})
 	if err != nil {
 		return err
@@ -925,10 +977,10 @@ func downloadFile(channel ssh3.Channel, remotePath, localPath string) error {
 	if statResp.Info != nil {
 		total = statResp.Info.Size
 	}
-	return downloadFileContents(channel, remotePath, localPath, total)
+	return downloadFileContents(channel, remotePath, localPath, total, cancel)
 }
 
-func uploadFile(channel ssh3.Channel, localPath, remotePath string) error {
+func uploadFile(channel ssh3.Channel, localPath, remotePath string, cancel *transferCancel) error {
 	f, err := os.Open(localPath)
 	if err != nil {
 		return err
@@ -943,7 +995,7 @@ func uploadFile(channel ssh3.Channel, localPath, remotePath string) error {
 		return fmt.Errorf("cannot upload a directory")
 	}
 
-	prog := newProgress(filepath.Base(localPath), info.Size(), os.Stdout)
+	prog := newProgress(filepath.Base(localPath), info.Size(), os.Stdout, cancel)
 	done := false
 	defer func() {
 		if !done {
@@ -954,6 +1006,9 @@ func uploadFile(channel ssh3.Channel, localPath, remotePath string) error {
 	var offset int64
 	buf := make([]byte, ChunkSize)
 	for {
+		if prog.cancelled() {
+			return ErrCancelled
+		}
 		n, err := f.Read(buf)
 		if err != nil && err != io.EOF {
 			return err

--- a/sftp/progress.go
+++ b/sftp/progress.go
@@ -32,12 +32,15 @@ type progress struct {
 	drawn    bool
 	out      io.Writer
 	inplace  bool
+	cancel   *transferCancel
 }
 
 // newProgress creates a progress reporter for the transfer of name whose
 // total size is total bytes (0 when unknown). Output is written to out and,
-// when out is a terminal, updated in place with carriage returns.
-func newProgress(name string, total int64, out io.Writer) *progress {
+// when out is a terminal, updated in place with carriage returns. cancel is
+// the cancellation flag of the enclosing transfer (nil when the transfer is
+// not cancellable).
+func newProgress(name string, total int64, out io.Writer, cancel *transferCancel) *progress {
 	inplace := false
 	if f, ok := out.(*os.File); ok {
 		inplace = term.IsTerminal(int(f.Fd()))
@@ -48,7 +51,15 @@ func newProgress(name string, total int64, out io.Writer) *progress {
 		start:   time.Now(),
 		out:     out,
 		inplace: inplace,
+		cancel:  cancel,
 	}
+}
+
+// cancelled reports whether the transfer has been cancelled by the user
+// (Ctrl+C in interactive mode, SIGINT in scp mode). Transfer loops check it
+// between chunks and stop as soon as it is set.
+func (p *progress) cancelled() bool {
+	return p.cancel.cancelled()
 }
 
 // add records that n more bytes have been transferred. For terminal output

--- a/sftp/progress_test.go
+++ b/sftp/progress_test.go
@@ -62,7 +62,7 @@ func nanValue() float64 {
 
 func TestProgressNonTerminalPrintsFinalLineOnly(t *testing.T) {
 	var buf bytes.Buffer
-	p := newProgress("file.txt", 1000, &buf)
+	p := newProgress("file.txt", 1000, &buf, nil)
 	p.add(420)
 	// Non-terminal output: nothing is drawn until finish.
 	if buf.Len() != 0 {
@@ -79,7 +79,7 @@ func TestProgressNonTerminalPrintsFinalLineOnly(t *testing.T) {
 
 func TestProgressUnknownTotalOmitsPercentage(t *testing.T) {
 	var buf bytes.Buffer
-	p := newProgress("unknown.bin", 0, &buf)
+	p := newProgress("unknown.bin", 0, &buf, nil)
 	p.add(2048)
 	p.finish()
 	got := buf.String()

--- a/sftp/quoting_test.go
+++ b/sftp/quoting_test.go
@@ -575,7 +575,7 @@ func TestClientDoGetQuotedPath(t *testing.T) {
 		makeJSONDataMsg(&Response{OK: true, Data: []byte{}}),
 	)
 	// parts simulate the output of makeargv("get 'Downloads/Test File.txt'").
-	if err := doGet(ch, localDir, "/remote", []string{"get", "Downloads/Test File.txt"}); err != nil {
+	if err := doGet(ch, localDir, "/remote", []string{"get", "Downloads/Test File.txt"}, nil); err != nil {
 		t.Fatalf("doGet error: %v", err)
 	}
 	var got Request
@@ -609,7 +609,7 @@ func TestClientDoGetEscapedGlobMetachar(t *testing.T) {
 		makeJSONDataMsg(&Response{OK: true, Data: []byte{}}),
 	)
 	// parts simulate the output of makeargv("get 'foo*.txt'").
-	if err := doGet(ch, localDir, "/remote", []string{"get", `foo\*.txt`}); err != nil {
+	if err := doGet(ch, localDir, "/remote", []string{"get", `foo\*.txt`}, nil); err != nil {
 		t.Fatalf("doGet error: %v", err)
 	}
 	var got Request

--- a/sftp/readline.go
+++ b/sftp/readline.go
@@ -2,10 +2,12 @@ package sftp
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"io"
 	"os"
 	"strings"
+	"sync"
 	"unicode/utf8"
 
 	"golang.org/x/sys/unix"
@@ -34,6 +36,7 @@ type interactiveReader struct {
 	state    *term.State
 	scanner  *bufio.Scanner
 	editor   *lineEditor
+	watchWg  sync.WaitGroup // tracks the stdin watcher goroutine of the current transfer
 }
 
 func newInteractiveReader() (*interactiveReader, error) {
@@ -109,6 +112,11 @@ type lineEditor struct {
 	completer completeFunc
 	tabWord   string // word completed by the last Tab press
 	tabActive bool   // whether the next Tab on the same word lists the candidates
+	// bytes typed during a transfer, buffered by the stdin watcher so they
+	// appear at the next prompt instead of being lost; pendingMu guards them
+	// against concurrent appends while the editor drains them
+	pendingMu sync.Mutex
+	pending   []byte
 }
 
 func (e *lineEditor) read() (string, error) {
@@ -119,7 +127,7 @@ func (e *lineEditor) read() (string, error) {
 	e.render()
 
 	for {
-		b, err := e.reader.ReadByte()
+		b, err := e.nextByte()
 		if err != nil {
 			return "", err
 		}
@@ -197,7 +205,7 @@ func (e *lineEditor) read() (string, error) {
 				if b < 0x80 {
 					e.insertRune(rune(b))
 				} else {
-					r, err := readRune(e.reader, b)
+					r, err := e.readRune(b)
 					if err != nil {
 						return "", err
 					}
@@ -206,6 +214,22 @@ func (e *lineEditor) read() (string, error) {
 			}
 		}
 	}
+}
+
+// nextByte returns the next input byte, draining the bytes buffered by the
+// transfer watcher before reading from the terminal. Bytes typed while a
+// transfer was running must be consumed before the terminal is read again, so
+// no input is lost (or reordered) around a transfer.
+func (e *lineEditor) nextByte() (byte, error) {
+	e.pendingMu.Lock()
+	if len(e.pending) > 0 {
+		b := e.pending[0]
+		e.pending = e.pending[1:]
+		e.pendingMu.Unlock()
+		return b, nil
+	}
+	e.pendingMu.Unlock()
+	return e.reader.ReadByte()
 }
 
 // handleEscape processes the byte following ESC, decoding the terminal escape
@@ -712,8 +736,9 @@ func runeWidth(r rune) int {
 }
 
 // readRune reassembles a multibyte UTF-8 rune whose first byte has already
-// been consumed from r.
-func readRune(r *bufio.Reader, first byte) (rune, error) {
+// been consumed, reading the continuation bytes through nextByte so bytes
+// buffered by the transfer watcher are honored.
+func (e *lineEditor) readRune(first byte) (rune, error) {
 	n := 1
 	switch {
 	case first&0xE0 == 0xC0:
@@ -725,9 +750,61 @@ func readRune(r *bufio.Reader, first byte) (rune, error) {
 	}
 	seq := make([]byte, n)
 	seq[0] = first
-	if _, err := io.ReadFull(r, seq[1:]); err != nil {
-		return 0, err
+	for i := 1; i < n; i++ {
+		b, err := e.nextByte()
+		if err != nil {
+			return 0, err
+		}
+		seq[i] = b
 	}
 	rn, _ := utf8.DecodeRune(seq)
 	return rn, nil
+}
+
+// watchCancel watches stdin for Ctrl+C while a transfer is running. In raw
+// mode the terminal delivers Ctrl+C as byte 0x03 instead of raising SIGINT
+// (ISIG is disabled by term.MakeRaw), so the transfer loop cannot be
+// interrupted by a signal and must be told to stop. Any other bytes typed
+// during the transfer are buffered in the editor's pending buffer so they
+// appear at the next prompt instead of being lost. It exits when ctx is done
+// (the transfer has finished) or when stdin is gone.
+func (r *interactiveReader) watchCancel(ctx context.Context, cancel *transferCancel) {
+	defer r.watchWg.Done()
+	fd := int(r.in.Fd())
+	buf := make([]byte, 256)
+	var fds [1]unix.PollFd
+	fds[0].Fd = int32(fd)
+	fds[0].Events = unix.POLLIN
+	for {
+		// Poll with a timeout so the watcher notices ctx being done even when
+		// no input arrives; a bare blocking read could never be interrupted.
+		n, err := unix.Poll(fds[:], 100)
+		if err != nil {
+			if err == unix.EINTR {
+				continue
+			}
+			return
+		}
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+		if n == 0 {
+			continue
+		}
+		nr, err := unix.Read(fd, buf)
+		if err != nil || nr <= 0 {
+			return
+		}
+		for _, b := range buf[:nr] {
+			if b == 0x03 {
+				cancel.cancel()
+			} else {
+				r.editor.pendingMu.Lock()
+				r.editor.pending = append(r.editor.pending, b)
+				r.editor.pendingMu.Unlock()
+			}
+		}
+	}
 }

--- a/sftp/scp.go
+++ b/sftp/scp.go
@@ -16,6 +16,9 @@ import (
 // protocol (the same channel the interactive -sftp mode uses). upload selects
 // the direction: when true, localPath is copied to remotePath; when false,
 // remotePath is copied to localPath. recursive enables directory transfers.
+// While the copy runs, SIGINT (Ctrl+C) and SIGTERM cancel it: the transfer
+// stops at the next chunk boundary, partial local files are removed, and
+// ErrCancelled is returned.
 func RunScpClient(c *client.Client, upload bool, recursive bool, localPath, remotePath string) error {
 	channel, err := c.OpenChannel("sftp", 30000, 0)
 	if err != nil {
@@ -26,17 +29,23 @@ func RunScpClient(c *client.Client, upload bool, recursive bool, localPath, remo
 		return fmt.Errorf("could not open sftp channel: %w", err)
 	}
 
+	// Scp mode runs with a normal terminal, so Ctrl+C is delivered as SIGINT
+	// and cancels the transfer instead of killing the process mid-copy.
+	cancel := &transferCancel{}
+	stop := watchSignals(cancel)
+	defer stop()
+
 	if upload {
-		return scpUpload(channel, recursive, localPath, remotePath)
+		return scpUpload(channel, recursive, localPath, remotePath, cancel)
 	}
-	return scpDownload(channel, recursive, remotePath, localPath)
+	return scpDownload(channel, recursive, remotePath, localPath, cancel)
 }
 
 // scpUpload copies a local file or directory to the remote host. Mirroring
 // scp semantics, when the remote target is an existing directory or ends with
 // a path separator, the source is copied into it under its own basename
 // (e.g. `scp -r ./dir host:/tmp/` copies to /tmp/dir).
-func scpUpload(channel ssh3.Channel, recursive bool, localPath, remotePath string) error {
+func scpUpload(channel ssh3.Channel, recursive bool, localPath, remotePath string, cancel *transferCancel) error {
 	info, err := os.Stat(localPath)
 	if err != nil {
 		return fmt.Errorf("cannot stat local path %s: %w", localPath, err)
@@ -52,16 +61,16 @@ func scpUpload(channel ssh3.Channel, recursive bool, localPath, remotePath strin
 	}
 
 	if recursive {
-		return uploadRecursive(channel, localPath, remotePath)
+		return uploadRecursive(channel, localPath, remotePath, cancel)
 	}
-	return uploadFile(channel, localPath, remotePath)
+	return uploadFile(channel, localPath, remotePath, cancel)
 }
 
 // scpDownload copies a remote file or directory to the local machine.
 // Mirroring scp semantics, when the local target is an existing directory or
 // ends with a path separator, the remote source is copied into it under its
 // own basename (e.g. `scp -r host:/etc/nginx .` copies to ./nginx).
-func scpDownload(channel ssh3.Channel, recursive bool, remotePath, localPath string) error {
+func scpDownload(channel ssh3.Channel, recursive bool, remotePath, localPath string, cancel *transferCancel) error {
 	info, err := os.Stat(localPath)
 	if err == nil && info.IsDir() {
 		localPath = filepath.Join(localPath, filepath.Base(remotePath))
@@ -70,9 +79,9 @@ func scpDownload(channel ssh3.Channel, recursive bool, remotePath, localPath str
 	}
 
 	if recursive {
-		return downloadRecursive(channel, remotePath, localPath)
+		return downloadRecursive(channel, remotePath, localPath, cancel)
 	}
-	return downloadFile(channel, remotePath, localPath)
+	return downloadFile(channel, remotePath, localPath, cancel)
 }
 
 // isRemoteDir reports whether the remote path refers to an existing

--- a/sftp/scp_test.go
+++ b/sftp/scp_test.go
@@ -19,7 +19,7 @@ func TestScpUploadFileToTrailingSlashTarget(t *testing.T) {
 		makeJSONDataMsg(&Response{ID: 1, OK: true}),
 	)
 
-	if err := scpUpload(ch, false, localPath, "/tmp/"); err != nil {
+	if err := scpUpload(ch, false, localPath, "/tmp/", nil); err != nil {
 		t.Fatalf("scpUpload error: %v", err)
 	}
 
@@ -48,7 +48,7 @@ func TestScpUploadFileToExistingRemoteDir(t *testing.T) {
 		makeJSONDataMsg(&Response{ID: 2, OK: true}),
 	)
 
-	if err := scpUpload(ch, false, localPath, "/tmp/remotedir"); err != nil {
+	if err := scpUpload(ch, false, localPath, "/tmp/remotedir", nil); err != nil {
 		t.Fatalf("scpUpload error: %v", err)
 	}
 
@@ -83,7 +83,7 @@ func TestScpUploadFileToNewRemoteName(t *testing.T) {
 		makeJSONDataMsg(&Response{ID: 2, OK: true}),
 	)
 
-	if err := scpUpload(ch, false, localPath, "/tmp/remotefile"); err != nil {
+	if err := scpUpload(ch, false, localPath, "/tmp/remotefile", nil); err != nil {
 		t.Fatalf("scpUpload error: %v", err)
 	}
 
@@ -107,7 +107,7 @@ func TestScpUploadDirectoryWithoutRecursive(t *testing.T) {
 	os.Mkdir(localDir, 0755)
 
 	ch := newMockChannel()
-	err := scpUpload(ch, false, localDir, "/tmp/")
+	err := scpUpload(ch, false, localDir, "/tmp/", nil)
 	if err == nil {
 		t.Fatal("expected error for directory upload without -r")
 	}
@@ -149,7 +149,7 @@ func TestScpUploadRecursiveDirectoryToTrailingSlashTarget(t *testing.T) {
 		makeJSONDataMsg(&Response{ID: 8, OK: true}),
 	)
 
-	if err := scpUpload(ch, true, localDir, "/tmp/"); err != nil {
+	if err := scpUpload(ch, true, localDir, "/tmp/", nil); err != nil {
 		t.Fatalf("scpUpload -r error: %v", err)
 	}
 
@@ -179,7 +179,7 @@ func TestScpDownloadToExistingLocalDir(t *testing.T) {
 		makeJSONDataMsg(&Response{ID: 3, OK: true, Data: []byte{}}),
 	)
 
-	if err := scpDownload(ch, false, "/etc/remote.txt", tmp); err != nil {
+	if err := scpDownload(ch, false, "/etc/remote.txt", tmp, nil); err != nil {
 		t.Fatalf("scpDownload error: %v", err)
 	}
 
@@ -217,7 +217,7 @@ func TestScpDownloadToTrailingSlashLocalTarget(t *testing.T) {
 	)
 
 	target := filepath.Join(tmp, "out") + string(filepath.Separator)
-	if err := scpDownload(ch, false, "/etc/remote.txt", target); err != nil {
+	if err := scpDownload(ch, false, "/etc/remote.txt", target, nil); err != nil {
 		t.Fatalf("scpDownload error: %v", err)
 	}
 
@@ -244,7 +244,7 @@ func TestScpDownloadToNewLocalName(t *testing.T) {
 	)
 
 	newName := filepath.Join(tmp, "newname")
-	if err := scpDownload(ch, false, "/etc/remote.txt", newName); err != nil {
+	if err := scpDownload(ch, false, "/etc/remote.txt", newName, nil); err != nil {
 		t.Fatalf("scpDownload error: %v", err)
 	}
 
@@ -271,7 +271,7 @@ func TestScpDownloadRecursiveToExistingLocalDir(t *testing.T) {
 		makeJSONDataMsg(&Response{ID: 4, OK: true, Data: []byte{}}),
 	)
 
-	if err := scpDownload(ch, true, "/etc/nginx", tmp); err != nil {
+	if err := scpDownload(ch, true, "/etc/nginx", tmp, nil); err != nil {
 		t.Fatalf("scpDownload -r error: %v", err)
 	}
 
@@ -288,7 +288,7 @@ func TestScpDownloadRecursiveToExistingLocalDir(t *testing.T) {
 // path fails cleanly.
 func TestScpUploadMissingLocalFile(t *testing.T) {
 	ch := newMockChannel()
-	err := scpUpload(ch, false, "/nonexistent/file.txt", "/tmp/")
+	err := scpUpload(ch, false, "/nonexistent/file.txt", "/tmp/", nil)
 	if err == nil {
 		t.Fatal("expected error for missing local file")
 	}

--- a/sftp/sftp_test.go
+++ b/sftp/sftp_test.go
@@ -612,7 +612,7 @@ func TestDownloadFile(t *testing.T) {
 		makeJSONDataMsg(done),
 	)
 
-	if err := downloadFile(ch, "remote.txt", localPath); err != nil {
+	if err := downloadFile(ch, "remote.txt", localPath, nil); err != nil {
 		t.Fatalf("downloadFile error: %v", err)
 	}
 	got, err := os.ReadFile(localPath)
@@ -626,7 +626,7 @@ func TestDownloadFile(t *testing.T) {
 
 func TestDownloadFile_StatFail(t *testing.T) {
 	ch := newMockChannel(makeJSONDataMsg(&Response{ID: 1, OK: false, Error: "no such file"}))
-	err := downloadFile(ch, "missing", filepath.Join(t.TempDir(), "out"))
+	err := downloadFile(ch, "missing", filepath.Join(t.TempDir(), "out"), nil)
 	if err == nil {
 		t.Fatal("expected error for stat failure")
 	}
@@ -644,7 +644,7 @@ func TestUploadFile(t *testing.T) {
 
 	// Verify that uploadFile sends the data through the channel without error.
 	// The remote side would write the file; our mock just acknowledges.
-	if err := uploadFile(ch, localPath, "remote.txt"); err != nil {
+	if err := uploadFile(ch, localPath, "remote.txt", nil); err != nil {
 		t.Fatalf("uploadFile error: %v", err)
 	}
 	// One chunk was sent because the content is smaller than ChunkSize.
@@ -668,7 +668,7 @@ func TestDownloadRecursive(t *testing.T) {
 		makeJSONDataMsg(&Response{ID: 8, OK: true, Data: []byte{}}),
 	)
 
-	if err := downloadRecursive(ch, "remote-dir", localRoot); err != nil {
+	if err := downloadRecursive(ch, "remote-dir", localRoot, nil); err != nil {
 		t.Fatalf("downloadRecursive error: %v", err)
 	}
 
@@ -704,7 +704,7 @@ func TestUploadRecursive(t *testing.T) {
 		makeJSONDataMsg(&Response{ID: 5, OK: true}),
 	)
 
-	if err := uploadRecursive(ch, localRoot, "remote-dir"); err != nil {
+	if err := uploadRecursive(ch, localRoot, "remote-dir", nil); err != nil {
 		t.Fatalf("uploadRecursive error: %v", err)
 	}
 	if len(ch.Writes) != 5 {
@@ -718,7 +718,7 @@ func TestUploadFile_DirectoryError(t *testing.T) {
 	os.Mkdir(dirPath, 0755)
 
 	ch := newMockChannel()
-	err := uploadFile(ch, dirPath, "/remote/file")
+	err := uploadFile(ch, dirPath, "/remote/file", nil)
 	if err == nil || err.Error() != "cannot upload a directory" {
 		t.Fatalf("expected directory upload error, got: %v", err)
 	}
@@ -1437,7 +1437,7 @@ func TestClientDoGetNoGlob(t *testing.T) {
 		makeJSONDataMsg(&Response{OK: true, Data: []byte{}}),
 	)
 
-	if err := doGet(ch, localDir, "/remote", []string{"get", "remote.txt"}); err != nil {
+	if err := doGet(ch, localDir, "/remote", []string{"get", "remote.txt"}, nil); err != nil {
 		t.Fatalf("doGet error: %v", err)
 	}
 
@@ -1473,7 +1473,7 @@ func TestClientDoGetWildcard(t *testing.T) {
 		makeJSONDataMsg(&Response{OK: true, Data: []byte{}}),
 	)
 
-	if err := doGet(ch, localDir, "/remote/path", []string{"get", "test*"}); err != nil {
+	if err := doGet(ch, localDir, "/remote/path", []string{"get", "test*"}, nil); err != nil {
 		t.Fatalf("doGet error: %v", err)
 	}
 
@@ -1512,7 +1512,7 @@ func TestClientDoGetNoMatch(t *testing.T) {
 		Entries: lsEntries("one", "two"),
 	}))
 
-	if err := doGet(ch, localDir, "/remote", []string{"get", "zzz*"}); err != nil {
+	if err := doGet(ch, localDir, "/remote", []string{"get", "zzz*"}, nil); err != nil {
 		t.Fatalf("doGet error: %v", err)
 	}
 	if len(ch.Writes) != 1 {
@@ -1529,7 +1529,7 @@ func TestClientDoGetNoMatch(t *testing.T) {
 
 func TestClientDoGetInvalidPattern(t *testing.T) {
 	ch := newMockChannel(makeJSONDataMsg(&Response{OK: true, Entries: lsEntries("a")}))
-	err := doGet(ch, t.TempDir(), "/remote", []string{"get", "["})
+	err := doGet(ch, t.TempDir(), "/remote", []string{"get", "["}, nil)
 	if err == nil {
 		t.Fatal("expected error for invalid glob pattern")
 	}
@@ -1545,7 +1545,7 @@ func TestClientDoGetRecursiveDir(t *testing.T) {
 		makeJSONDataMsg(&Response{OK: true, Data: []byte{}}),
 	)
 
-	if err := doGet(ch, localDir, "/remote", []string{"get", "-r", "d"}); err != nil {
+	if err := doGet(ch, localDir, "/remote", []string{"get", "-r", "d"}, nil); err != nil {
 		t.Fatalf("doGet -r dir error: %v", err)
 	}
 
@@ -1584,7 +1584,7 @@ func TestClientDoGetRecursiveWildcard(t *testing.T) {
 		makeJSONDataMsg(&Response{OK: true, Data: []byte{}}),
 	)
 
-	if err := doGet(ch, localDir, "/remote/path", []string{"get", "-r", "test*"}); err != nil {
+	if err := doGet(ch, localDir, "/remote/path", []string{"get", "-r", "test*"}, nil); err != nil {
 		t.Fatalf("doGet -r wildcard error: %v", err)
 	}
 
@@ -1631,7 +1631,7 @@ func TestClientDoGetRecursiveWildcardNoMatch(t *testing.T) {
 		Entries: lsEntries("one", "two"),
 	}))
 
-	if err := doGet(ch, localDir, "/remote", []string{"get", "-r", "zzz*"}); err != nil {
+	if err := doGet(ch, localDir, "/remote", []string{"get", "-r", "zzz*"}, nil); err != nil {
 		t.Fatalf("doGet error: %v", err)
 	}
 	if len(ch.Writes) != 1 {


### PR DESCRIPTION
Ctrl+C now cancels an upload or download instead of being ignored during the transfer (interactive sftp) or killing the process mid-copy (scp):

- scp mode: SIGINT/SIGTERM set a cancel flag checked between chunks; the copy stops at the next chunk boundary, partially downloaded local files are removed, and the client exits with status 130 like a process killed by SIGINT.
- interactive sftp: the terminal is raw, so Ctrl+C arrives as byte 0x03; a stdin watcher consumes it during transfers and cancels, printing 'Cancelled' and returning to the prompt. Other bytes typed during a transfer are buffered and replayed at the next prompt instead of being lost. Partial downloads are removed.
- the cancel flag is threaded through doGet/downloadOne/downloadRecursive/ downloadFileContents/uploadRecursive/uploadFile, which check it between chunks; the in-place progress line is cleared before reporting the cancellation.

Tests cover chunk-boundary cancellation for uploads, downloads and recursive transfers, the SIGINT/SIGTERM watcher, and the interactive stdin watcher (Ctrl+C detection, typed-ahead buffering, clean shutdown).