### PR TITLE
feat: OpenSSH-style cd shortcuts in the SFTP client

### DIFF
--- a/sftp/client.go
+++ b/sftp/client.go
@@ -31,6 +31,17 @@ func RunInteractiveClient(c *client.Client) error {
 
 	localDir, _ := os.Getwd()
 	remoteDir := "."
+	// The server starts every SFTP session in the authenticated user's home
+	// directory, so the first pwd reveals it. It backs the `cd`/`cd ~` →
+	// $HOME behavior, like OpenSSH sftp's bare `cd`.
+	homeDir := remoteDir
+	if pwdResp, err := doRequest(channel, &Request{Cmd: "pwd"}); err == nil && pwdResp.OK {
+		remoteDir = pwdResp.Path
+		homeDir = pwdResp.Path
+	}
+	// The previous remote directory, for `cd -`.
+	prevDir := ""
+	hasPrevDir := false
 
 	input, err := newInteractiveReader()
 	if err != nil {
@@ -101,14 +112,14 @@ func RunInteractiveClient(c *client.Client) error {
 			fmt.Println(localDir)
 
 		case "cd":
-			target := remoteDir
+			arg := ""
 			if len(parts) > 1 {
-				arg := undoGlobEscape(parts[1])
-				if path.IsAbs(arg) {
-					target = arg
-				} else {
-					target = path.Join(remoteDir, arg)
-				}
+				arg = undoGlobEscape(parts[1])
+			}
+			target, ok := resolveCDTarget(arg, remoteDir, homeDir, prevDir, hasPrevDir)
+			if !ok {
+				fmt.Fprintln(os.Stderr, "cd: no previous directory")
+				continue
 			}
 			resp, err := doRequest(channel, &Request{Cmd: "cd", Path: target})
 			if err != nil {
@@ -118,6 +129,7 @@ func RunInteractiveClient(c *client.Client) error {
 			if !resp.OK {
 				fmt.Fprintf(os.Stderr, "cd: %s\n", resp.Error)
 			} else {
+				prevDir, hasPrevDir = remoteDir, true
 				pwdResp, _ := doRequest(channel, &Request{Cmd: "pwd"})
 				if pwdResp != nil && pwdResp.OK {
 					remoteDir = pwdResp.Path
@@ -257,6 +269,30 @@ func RunInteractiveClient(c *client.Client) error {
 	}
 
 	return nil
+}
+
+// resolveCDTarget computes the remote path a `cd` command should change to,
+// mirroring OpenSSH sftp and shell cd semantics:
+//   - no argument, "~" or "~/..." resolve to the user's home directory;
+//   - "-" resolves to the previous directory (ok is false when there is none);
+//   - absolute paths are used as-is;
+//   - any other path is resolved against the current remote directory.
+func resolveCDTarget(arg, remoteDir, homeDir, prevDir string, hasPrevDir bool) (target string, ok bool) {
+	switch {
+	case arg == "" || arg == "~":
+		return homeDir, true
+	case strings.HasPrefix(arg, "~/"):
+		return path.Join(homeDir, arg[2:]), true
+	case arg == "-":
+		if !hasPrevDir {
+			return "", false
+		}
+		return prevDir, true
+	case path.IsAbs(arg):
+		return arg, true
+	default:
+		return path.Join(remoteDir, arg), true
+	}
 }
 
 // newCompleter builds the tab-completion callback for the interactive SFTP
@@ -854,7 +890,8 @@ func ensureRemoteDir(channel ssh3.Channel, remotePath string) error {
 
 func printHelp() {
 	fmt.Println(`Commands:
-  cd <path>       change remote directory
+  cd [path]       change remote directory (no argument or "~" goes to $HOME,
+                  "-" goes to the previous directory)
   ls [path]       list remote directory (path may contain * ? [glob] patterns)
   pwd             print remote working directory
   get [-r] <src> [dst]   download remote file or directory (src may contain * ? [glob] patterns)

--- a/sftp/sftp_test.go
+++ b/sftp/sftp_test.go
@@ -1645,3 +1645,42 @@ func TestClientDoGetRecursiveWildcardNoMatch(t *testing.T) {
 		t.Errorf("expected no downloads for non-matching recursive glob, got %d files", len(entries))
 	}
 }
+
+func TestResolveCDTarget(t *testing.T) {
+	const (
+		remoteDir = "/home/alice/work"
+		homeDir   = "/home/alice"
+		prevDir   = "/home/alice/projects"
+	)
+
+	tests := []struct {
+		name       string
+		arg        string
+		hasPrevDir bool
+		want       string
+		wantOK     bool
+	}{
+		{name: "no argument goes to home", arg: "", want: homeDir, wantOK: true},
+		{name: "tilde goes to home", arg: "~", want: homeDir, wantOK: true},
+		{name: "tilde slash subdir", arg: "~/docs", want: homeDir + "/docs", wantOK: true},
+		{name: "tilde slash nested", arg: "~/a/b/c", want: homeDir + "/a/b/c", wantOK: true},
+		{name: "bare tilde slash", arg: "~/", want: homeDir, wantOK: true},
+		{name: "dash goes to previous dir", arg: "-", hasPrevDir: true, want: prevDir, wantOK: true},
+		{name: "dash without previous dir fails", arg: "-", wantOK: false},
+		{name: "absolute path used as-is", arg: "/tmp", want: "/tmp", wantOK: true},
+		{name: "relative path joined to remote dir", arg: "sub", want: remoteDir + "/sub", wantOK: true},
+		{name: "relative dot", arg: ".", want: remoteDir, wantOK: true},
+		{name: "relative parent", arg: "..", want: homeDir, wantOK: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := resolveCDTarget(tt.arg, remoteDir, homeDir, prevDir, tt.hasPrevDir)
+			if ok != tt.wantOK {
+				t.Fatalf("resolveCDTarget(%q) ok = %v, want %v", tt.arg, ok, tt.wantOK)
+			}
+			if got != tt.want {
+				t.Fatalf("resolveCDTarget(%q) = %q, want %q", tt.arg, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
- bare 'cd' and 'cd ~'/'cd ~/...' return to the user's home directory
- 'cd -' switches to the previous directory (toggling on repeat)
- the home directory is discovered from the session's initial pwd, which the server always starts at the authenticated user's home

Adds unit tests for the new cd target resolution.