### PR TITLE
feat: support wildcards for put/get source files in the SFTP client

### DIFF
--- a/sftp/client.go
+++ b/sftp/client.go
@@ -169,31 +169,9 @@ func RunInteractiveClient(c *client.Client) error {
 			}
 
 		case "put":
-			recursive, localSource, remoteTarget, err := parseTransferArgs(parts, "put")
-			if err != nil {
-				fmt.Println(err.Error())
-				continue
-			}
-			// The source is not globbed by this client, so the escaped path is
-			// fully un-escaped to the literal file name.
-			localFile := unescape(localSource)
-			if !filepath.IsAbs(localFile) {
-				localFile = filepath.Join(localDir, localFile)
-			}
-			remoteFile := undoGlobEscape(remoteTarget)
-			if remoteFile == "" {
-				remoteFile = filepath.Base(localFile)
-			}
-			if !path.IsAbs(remoteFile) {
-				remoteFile = path.Join(remoteDir, remoteFile)
-			}
-
 			cancel := &transferCancel{}
-			err = input.runTransfer(cancel, func() error {
-				if recursive {
-					return uploadRecursive(channel, localFile, remoteFile, cancel)
-				}
-				return uploadFile(channel, localFile, remoteFile, cancel)
+			err := input.runTransfer(cancel, func() error {
+				return doPut(channel, localDir, remoteDir, parts, cancel)
 			})
 			if err != nil {
 				if errors.Is(err, ErrCancelled) {
@@ -615,16 +593,48 @@ func doGet(channel ssh3.Channel, localDir, remoteDir string, parts []string, can
 		if !resp.OK {
 			return fmt.Errorf("%s", resp.Error)
 		}
+		var matched []FileInfo
 		for _, e := range resp.Entries {
 			ok, err := path.Match(pattern, e.Name)
 			if err != nil {
 				return fmt.Errorf("invalid pattern \"%s\": %w", pattern, err)
 			}
-			if !ok {
-				continue
+			if ok {
+				matched = append(matched, e)
 			}
+		}
+
+		// The local destination is a literal path (not globbed): remove the
+		// escaping makeargv preserved for glob matching and resolve it against
+		// the local working directory. A trailing separator marks the
+		// destination as a directory even when it does not exist yet;
+		// otherwise an existing local directory is detected with a stat.
+		destDir := localDir
+		destIsDir := true
+		if target := undoGlobEscape(localTarget); target != "" {
+			destDir = resolveLocalPath(localDir, target)
+			destIsDir = false
+			if strings.HasSuffix(target, string(filepath.Separator)) {
+				destIsDir = true
+			} else if info, err := os.Stat(destDir); err == nil && info.IsDir() {
+				destIsDir = true
+			}
+		}
+
+		// A single match may target a file name; multiple matches require a
+		// directory destination (or none, in which case the files are placed
+		// in the local working directory).
+		if len(matched) > 1 && !destIsDir {
+			return fmt.Errorf("cannot download %d files to %s: not a directory", len(matched), destDir)
+		}
+
+		for _, e := range matched {
 			remoteFile := path.Join(sourceDir, e.Name)
-			localFile := filepath.Join(localDir, filepath.Base(filepath.Clean(remoteFile)))
+			localFile := filepath.Join(destDir, e.Name)
+			if len(matched) == 1 && !destIsDir {
+				// A single match may target a file name directly.
+				localFile = destDir
+			}
 			if err := downloadOne(channel, remoteFile, localFile, recursive, cancel); err != nil {
 				return err
 			}
@@ -632,15 +642,26 @@ func doGet(channel ssh3.Channel, localDir, remoteDir string, parts []string, can
 		return nil
 	}
 
-	// No glob: preserve the previous single-target behavior.
+	// No glob: preserve the previous single-target behavior, but still resolve
+	// a destination that names an existing local directory (or ends with a
+	// path separator) by copying the file into it under its own basename,
+	// mirroring the scp/download semantics.
 	remoteFile := sourceDir
 	// The local target is not globbed: undo the escaping of glob
 	// metacharacters, mirroring OpenSSH's undo_glob_escape for get targets.
 	localFile := undoGlobEscape(localTarget)
-	if localFile == "" {
-		localFile = filepath.Base(filepath.Clean(remoteFile))
+	base := filepath.Base(filepath.Clean(remoteFile))
+	switch {
+	case localFile == "":
+		localFile = base
+	case strings.HasSuffix(localFile, string(filepath.Separator)):
+		localFile = filepath.Join(localFile, base)
+	default:
+		if info, err := os.Stat(resolveLocalPath(localDir, localFile)); err == nil && info.IsDir() {
+			localFile = filepath.Join(localFile, base)
+		}
 	}
-	localFile = filepath.Join(localDir, localFile)
+	localFile = resolveLocalPath(localDir, localFile)
 	return downloadOne(channel, remoteFile, localFile, recursive, cancel)
 }
 
@@ -653,6 +674,105 @@ func downloadOne(channel ssh3.Channel, remoteFile, localFile string, recursive b
 		return downloadRecursive(channel, remoteFile, localFile, cancel)
 	}
 	return downloadFile(channel, remoteFile, localFile, cancel)
+}
+
+// doPut uploads a local file or directory, or every local file matching a
+// glob pattern in the source, to the remote filesystem. The source is
+// expanded against the local filesystem with filepath.Glob, which understands
+// the backslash escaping that makeargv preserves for glob metacharacters, so
+// escaped metacharacters are matched literally. When the pattern matches
+// nothing it is used as a literal path (mirroring OpenSSH's GLOB_NOCHECK), so
+// the transfer fails with the underlying "no such file" error. The -r flag
+// is honored in both cases: directories (whether matched by the pattern or
+// named directly) are transferred recursively via uploadOne. The remote
+// target is a literal path (not globbed): a single source may target a file
+// name or a directory, while multiple sources require an existing directory
+// (or no target, in which case each source is uploaded under its own
+// basename).
+func doPut(channel ssh3.Channel, localDir, remoteDir string, parts []string, cancel *transferCancel) error {
+	recursive, localSource, remoteTarget, err := parseTransferArgs(parts, "put")
+	if err != nil {
+		return err
+	}
+
+	// Expand a possibly-globbed source against the local filesystem. The
+	// pattern is resolved against the local working directory (the process
+	// working directory tracks it via lcd, but this keeps the source
+	// independent of the process CWD). filepath.Glob understands the backslash
+	// escaping that makeargv preserves for glob metacharacters, so escaped
+	// metacharacters are matched literally.
+	globSource := localSource
+	if !filepath.IsAbs(globSource) {
+		globSource = filepath.Join(localDir, localSource)
+	}
+	matches, globErr := filepath.Glob(globSource)
+	if globErr != nil {
+		return fmt.Errorf("invalid pattern \"%s\": %w", localSource, globErr)
+	}
+	if len(matches) == 0 {
+		// No matches: fall back to the literal path so the transfer fails with
+		// the underlying "no such file" error, mirroring OpenSSH's GLOB_NOCHECK
+		// behavior.
+		matches = []string{unescape(localSource)}
+	}
+
+	// The remote target is a literal path (not globbed): remove the escaping
+	// makeargv preserved for glob matching, then resolve it against the remote
+	// working directory for the directory check.
+	remoteTarget = undoGlobEscape(remoteTarget)
+	resolvedTarget := remoteTarget
+	if resolvedTarget != "" && !path.IsAbs(resolvedTarget) {
+		resolvedTarget = path.Join(remoteDir, resolvedTarget)
+	}
+
+	// A trailing separator marks the target as a directory even when it does
+	// not exist yet; an existing remote directory is detected with a stat.
+	targetIsDir := strings.HasSuffix(remoteTarget, "/")
+	if remoteTarget != "" && !targetIsDir && isRemoteDir(channel, resolvedTarget) {
+		targetIsDir = true
+	}
+
+	// A single source may target a file name; multiple sources require a
+	// directory target (or none, in which case each source is uploaded under
+	// its own basename).
+	if len(matches) > 1 && remoteTarget != "" && !targetIsDir {
+		return fmt.Errorf("cannot upload %d files to %s: not a directory", len(matches), remoteTarget)
+	}
+
+	for _, match := range matches {
+		localFile := match
+		if !filepath.IsAbs(localFile) {
+			localFile = filepath.Join(localDir, localFile)
+		}
+
+		remoteFile := filepath.Base(match)
+		switch {
+		case remoteTarget == "":
+			// The basename, uploaded into remoteDir below.
+		case targetIsDir:
+			remoteFile = path.Join(remoteTarget, remoteFile)
+		default:
+			remoteFile = remoteTarget
+		}
+		if !path.IsAbs(remoteFile) {
+			remoteFile = path.Join(remoteDir, remoteFile)
+		}
+
+		if err := uploadOne(channel, localFile, remoteFile, recursive, cancel); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// resolveLocalPath joins p with localDir when p is relative, returning p
+// unchanged when it is absolute. localDir is the client's current local
+// working directory, which is always absolute.
+func resolveLocalPath(localDir, p string) string {
+	if filepath.IsAbs(p) {
+		return p
+	}
+	return filepath.Join(localDir, p)
 }
 
 // globSplit reports whether arg contains unescaped glob metacharacters in its
@@ -818,6 +938,16 @@ func downloadFileContents(channel ssh3.Channel, remotePath, localPath string, to
 	return nil
 }
 
+// uploadOne uploads localFile to remoteFile, descending into directories when
+// recursive is set. It is the upload counterpart of downloadOne and is shared
+// by the glob and non-glob paths of doPut.
+func uploadOne(channel ssh3.Channel, localFile, remoteFile string, recursive bool, cancel *transferCancel) error {
+	if recursive {
+		return uploadRecursive(channel, localFile, remoteFile, cancel)
+	}
+	return uploadFile(channel, localFile, remoteFile, cancel)
+}
+
 func uploadRecursive(channel ssh3.Channel, localPath, remotePath string, cancel *transferCancel) error {
 	if cancel.cancelled() {
 		return ErrCancelled
@@ -895,7 +1025,7 @@ func printHelp() {
   ls [path]       list remote directory (path may contain * ? [glob] patterns)
   pwd             print remote working directory
   get [-r] <src> [dst]   download remote file or directory (src may contain * ? [glob] patterns)
-  put [-r] <src> [dst]   upload local file or directory
+  put [-r] <src> [dst]   upload local file or directory (src may contain * ? [glob] patterns)
   mkdir <path>    create remote directory
   rm <file>       remove remote file
   rmdir <dir>     remove remote directory

--- a/sftp/sftp_test.go
+++ b/sftp/sftp_test.go
@@ -1646,6 +1646,497 @@ func TestClientDoGetRecursiveWildcardNoMatch(t *testing.T) {
 	}
 }
 
+func TestClientDoPutWildcard(t *testing.T) {
+	localDir := t.TempDir()
+	os.WriteFile(filepath.Join(localDir, "a.txt"), []byte("A"), 0644)
+	os.WriteFile(filepath.Join(localDir, "b.txt"), []byte("B"), 0644)
+	os.WriteFile(filepath.Join(localDir, "c.log"), []byte("C"), 0644)
+
+	ch := newMockChannel(
+		makeJSONDataMsg(&Response{ID: 1, OK: true}), // put a.txt
+		makeJSONDataMsg(&Response{ID: 2, OK: true}), // put b.txt
+	)
+
+	if err := doPut(ch, localDir, "/remote", []string{"put", "*.txt"}, nil); err != nil {
+		t.Fatalf("doPut error: %v", err)
+	}
+
+	if len(ch.Writes) != 2 {
+		t.Fatalf("expected 2 requests, got %d", len(ch.Writes))
+	}
+	var got Request
+	if err := json.Unmarshal(ch.Writes[0], &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.Cmd != "put" || got.Path != "/remote/a.txt" {
+		t.Errorf("expected put /remote/a.txt, got %s %q", got.Cmd, got.Path)
+	}
+	if err := json.Unmarshal(ch.Writes[1], &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.Cmd != "put" || got.Path != "/remote/b.txt" {
+		t.Errorf("expected put /remote/b.txt, got %s %q", got.Cmd, got.Path)
+	}
+}
+
+// TestClientDoPutWildcardSubdirPattern verifies that a put source whose
+// pattern spans a directory (e.g. sub/*.txt) is expanded against the local
+// filesystem, uploading each match under its basename.
+func TestClientDoPutWildcardSubdirPattern(t *testing.T) {
+	localDir := t.TempDir()
+	os.MkdirAll(filepath.Join(localDir, "sub"), 0o755)
+	os.WriteFile(filepath.Join(localDir, "sub", "one.txt"), []byte("1"), 0644)
+	os.WriteFile(filepath.Join(localDir, "sub", "two.TXT"), []byte("2"), 0644)
+	os.WriteFile(filepath.Join(localDir, "top.txt"), []byte("T"), 0644)
+
+	ch := newMockChannel(makeJSONDataMsg(&Response{ID: 1, OK: true}))
+
+	if err := doPut(ch, localDir, "/remote", []string{"put", "sub/*.txt"}, nil); err != nil {
+		t.Fatalf("doPut error: %v", err)
+	}
+	if len(ch.Writes) != 1 {
+		t.Fatalf("expected 1 request, got %d", len(ch.Writes))
+	}
+	var got Request
+	if err := json.Unmarshal(ch.Writes[0], &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.Cmd != "put" || got.Path != "/remote/one.txt" {
+		t.Fatalf("expected put /remote/one.txt, got %s %q", got.Cmd, got.Path)
+	}
+}
+
+// TestClientDoPutWildcardToRemoteDir verifies that a multi-match put to an
+// existing remote directory uploads each source into that directory under its
+// own basename.
+func TestClientDoPutWildcardToRemoteDir(t *testing.T) {
+	localDir := t.TempDir()
+	os.WriteFile(filepath.Join(localDir, "a.log"), []byte("A"), 0644)
+	os.WriteFile(filepath.Join(localDir, "b.log"), []byte("B"), 0644)
+
+	ch := newMockChannel(
+		makeJSONDataMsg(&Response{ID: 1, OK: true, Info: &FileInfo{Name: "logs", IsDir: true}}), // stat /remote/logs
+		makeJSONDataMsg(&Response{ID: 2, OK: true}),                                             // put a.log
+		makeJSONDataMsg(&Response{ID: 3, OK: true}),                                             // put b.log
+	)
+
+	if err := doPut(ch, localDir, "/remote", []string{"put", "*.log", "logs"}, nil); err != nil {
+		t.Fatalf("doPut error: %v", err)
+	}
+
+	if len(ch.Writes) != 3 {
+		t.Fatalf("expected 3 requests, got %d", len(ch.Writes))
+	}
+	var got Request
+	if err := json.Unmarshal(ch.Writes[1], &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.Cmd != "put" || got.Path != "/remote/logs/a.log" {
+		t.Errorf("expected put /remote/logs/a.log, got %s %q", got.Cmd, got.Path)
+	}
+	if err := json.Unmarshal(ch.Writes[2], &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.Cmd != "put" || got.Path != "/remote/logs/b.log" {
+		t.Errorf("expected put /remote/logs/b.log, got %s %q", got.Cmd, got.Path)
+	}
+}
+
+// TestClientDoPutWildcardToNonDirectory verifies that a multi-match put to a
+// non-directory remote target fails without uploading anything.
+func TestClientDoPutWildcardToNonDirectory(t *testing.T) {
+	localDir := t.TempDir()
+	os.WriteFile(filepath.Join(localDir, "a.log"), []byte("A"), 0644)
+	os.WriteFile(filepath.Join(localDir, "b.log"), []byte("B"), 0644)
+
+	ch := newMockChannel(makeJSONDataMsg(&Response{ID: 1, OK: false, Error: "no such file"}))
+
+	err := doPut(ch, localDir, "/remote", []string{"put", "*.log", "logs"}, nil)
+	if err == nil {
+		t.Fatal("expected error for multi-match put to non-directory")
+	}
+	if !strings.Contains(err.Error(), "not a directory") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+// TestClientDoPutSingleToRemoteDir verifies that a single-source put to an
+// existing remote directory copies the file into it under its own basename.
+func TestClientDoPutSingleToRemoteDir(t *testing.T) {
+	localDir := t.TempDir()
+	os.WriteFile(filepath.Join(localDir, "a.txt"), []byte("A"), 0644)
+
+	ch := newMockChannel(
+		makeJSONDataMsg(&Response{ID: 1, OK: true, Info: &FileInfo{Name: "dir", IsDir: true}}),
+		makeJSONDataMsg(&Response{ID: 2, OK: true}),
+	)
+
+	if err := doPut(ch, localDir, "/remote", []string{"put", "a.txt", "dir"}, nil); err != nil {
+		t.Fatalf("doPut error: %v", err)
+	}
+	if len(ch.Writes) != 2 {
+		t.Fatalf("expected 2 requests, got %d", len(ch.Writes))
+	}
+	var got Request
+	if err := json.Unmarshal(ch.Writes[1], &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.Cmd != "put" || got.Path != "/remote/dir/a.txt" {
+		t.Fatalf("expected put /remote/dir/a.txt, got %s %q", got.Cmd, got.Path)
+	}
+}
+
+// TestClientDoPutSingleToNewName verifies that a single-source put to a target
+// that is neither an existing directory nor slash-terminated uses the target
+// as the remote file name verbatim.
+func TestClientDoPutSingleToNewName(t *testing.T) {
+	localDir := t.TempDir()
+	os.WriteFile(filepath.Join(localDir, "a.txt"), []byte("A"), 0644)
+
+	ch := newMockChannel(
+		makeJSONDataMsg(&Response{ID: 1, OK: false, Error: "no such file"}),
+		makeJSONDataMsg(&Response{ID: 2, OK: true}),
+	)
+
+	if err := doPut(ch, localDir, "/remote", []string{"put", "a.txt", "newname"}, nil); err != nil {
+		t.Fatalf("doPut error: %v", err)
+	}
+	if len(ch.Writes) != 2 {
+		t.Fatalf("expected 2 requests, got %d", len(ch.Writes))
+	}
+	var got Request
+	if err := json.Unmarshal(ch.Writes[1], &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.Cmd != "put" || got.Path != "/remote/newname" {
+		t.Fatalf("expected put /remote/newname, got %s %q", got.Cmd, got.Path)
+	}
+}
+
+// TestClientDoPutEscapedGlob verifies that a glob metacharacter escaped with a
+// backslash is matched literally against the local filesystem, so a file named
+// "star*file" uploads as itself rather than being globbed.
+func TestClientDoPutEscapedGlob(t *testing.T) {
+	localDir := t.TempDir()
+	os.WriteFile(filepath.Join(localDir, "star*file"), []byte("S"), 0644)
+
+	ch := newMockChannel(makeJSONDataMsg(&Response{ID: 1, OK: true}))
+
+	// parts[1] is what makeargv produces for the typed `star\*file`.
+	if err := doPut(ch, localDir, "/remote", []string{"put", `star\*file`}, nil); err != nil {
+		t.Fatalf("doPut error: %v", err)
+	}
+	if len(ch.Writes) != 1 {
+		t.Fatalf("expected 1 request, got %d", len(ch.Writes))
+	}
+	var got Request
+	if err := json.Unmarshal(ch.Writes[0], &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.Cmd != "put" || got.Path != "/remote/star*file" {
+		t.Fatalf("expected put /remote/star*file, got %s %q", got.Cmd, got.Path)
+	}
+}
+
+// TestClientDoPutQuotedMetachar verifies the full parsing pipeline: a glob
+// metacharacter typed inside quotes is escaped by makeargv and then matched
+// literally by the local glob, so put 'star*file' uploads the literal file
+// (the same convention the get tests exercise).
+func TestClientDoPutQuotedMetachar(t *testing.T) {
+	localDir := t.TempDir()
+	os.WriteFile(filepath.Join(localDir, "star*file"), []byte("S"), 0644)
+
+	parts, _, _, _, err := makeargv(`put 'star*file'`, false)
+	if err != nil {
+		t.Fatalf("makeargv: %v", err)
+	}
+	if len(parts) != 2 {
+		t.Fatalf("expected 2 parts, got %v", parts)
+	}
+	if parts[1] != `star\*file` {
+		t.Fatalf("expected escaped source %q, got %q", `star\*file`, parts[1])
+	}
+
+	ch := newMockChannel(makeJSONDataMsg(&Response{OK: true}))
+	if err := doPut(ch, localDir, "/remote", parts, nil); err != nil {
+		t.Fatalf("doPut error: %v", err)
+	}
+
+	var got Request
+	if len(ch.Writes) != 1 {
+		t.Fatalf("expected 1 request, got %d", len(ch.Writes))
+	}
+	if err := json.Unmarshal(ch.Writes[0], &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.Cmd != "put" || got.Path != "/remote/star*file" {
+		t.Fatalf("expected put /remote/star*file, got %s %q", got.Cmd, got.Path)
+	}
+}
+
+// TestClientDoPutNoMatch verifies that a put source with no matching local
+// file falls back to the literal path and fails with the underlying error.
+func TestClientDoPutNoMatch(t *testing.T) {
+	localDir := t.TempDir()
+
+	ch := newMockChannel()
+	err := doPut(ch, localDir, "/remote", []string{"put", "zzz*.txt"}, nil)
+	if err == nil {
+		t.Fatal("expected error for non-matching put source")
+	}
+	if !strings.Contains(err.Error(), "no such file") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+// TestClientDoPutInvalidPattern verifies that a malformed put glob pattern is
+// rejected up front.
+func TestClientDoPutInvalidPattern(t *testing.T) {
+	localDir := t.TempDir()
+
+	ch := newMockChannel()
+	err := doPut(ch, localDir, "/remote", []string{"put", "["}, nil)
+	if err == nil {
+		t.Fatal("expected error for invalid glob pattern")
+	}
+}
+
+// TestClientDoPutRecursiveWildcard verifies that put -r with a glob source
+// transfers matched directories recursively through uploadOne.
+func TestClientDoPutRecursiveWildcard(t *testing.T) {
+	localDir := t.TempDir()
+	dirPath := filepath.Join(localDir, "d")
+	os.MkdirAll(dirPath, 0o755)
+	os.WriteFile(filepath.Join(dirPath, "f.txt"), []byte("hello"), 0644)
+	os.WriteFile(filepath.Join(localDir, "solo.txt"), []byte("solo"), 0644)
+
+	ch := newMockChannel(
+		makeJSONDataMsg(&Response{ID: 1, OK: false, Error: "no such file"}),                       // stat /remote/d
+		makeJSONDataMsg(&Response{ID: 2, OK: true, Info: &FileInfo{Name: "remote", IsDir: true}}), // stat /remote
+		makeJSONDataMsg(&Response{ID: 3, OK: true}),                                               // mkdir /remote/d
+		makeJSONDataMsg(&Response{ID: 4, OK: true}),                                               // put /remote/d/f.txt
+		makeJSONDataMsg(&Response{ID: 5, OK: true}),                                               // put /remote/solo.txt
+	)
+
+	if err := doPut(ch, localDir, "/remote", []string{"put", "-r", "*"}, nil); err != nil {
+		t.Fatalf("doPut -r error: %v", err)
+	}
+	if len(ch.Writes) != 5 {
+		t.Fatalf("expected 5 requests, got %d", len(ch.Writes))
+	}
+	var mkdirReq, putReq Request
+	if err := json.Unmarshal(ch.Writes[2], &mkdirReq); err != nil {
+		t.Fatalf("unmarshal mkdir: %v", err)
+	}
+	if mkdirReq.Cmd != "mkdir" || mkdirReq.Path != "/remote/d" {
+		t.Errorf("expected mkdir /remote/d, got %s %q", mkdirReq.Cmd, mkdirReq.Path)
+	}
+	if err := json.Unmarshal(ch.Writes[4], &putReq); err != nil {
+		t.Fatalf("unmarshal put: %v", err)
+	}
+	if putReq.Cmd != "put" || putReq.Path != "/remote/solo.txt" {
+		t.Errorf("expected put /remote/solo.txt, got %s %q", putReq.Cmd, putReq.Path)
+	}
+}
+
+// TestClientDoGetWildcardToLocalDir verifies that get with a glob source and an
+// existing local directory destination downloads each match into that
+// directory.
+func TestClientDoGetWildcardToLocalDir(t *testing.T) {
+	localDir := t.TempDir()
+	destDir := filepath.Join(localDir, "dest")
+	os.MkdirAll(destDir, 0o755)
+
+	ch := newMockChannel(
+		makeJSONDataMsg(&Response{OK: true, Entries: lsEntries("test", "testa", "nope")}),
+		makeJSONDataMsg(&Response{OK: true, Info: &FileInfo{Name: "test", Size: 5}}),
+		makeJSONDataMsg(&Response{OK: true, Data: []byte("hello")}),
+		makeJSONDataMsg(&Response{OK: true, Data: []byte{}}),
+		makeJSONDataMsg(&Response{OK: true, Info: &FileInfo{Name: "testa", Size: 5}}),
+		makeJSONDataMsg(&Response{OK: true, Data: []byte("world")}),
+		makeJSONDataMsg(&Response{OK: true, Data: []byte{}}),
+	)
+
+	if err := doGet(ch, localDir, "/remote/path", []string{"get", "test*", "dest"}, nil); err != nil {
+		t.Fatalf("doGet error: %v", err)
+	}
+
+	// The ls request must target the source parent directory, not the
+	// destination.
+	var got Request
+	if err := json.Unmarshal(ch.Writes[0], &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.Cmd != "ls" || got.Path != "/remote/path" {
+		t.Fatalf("expected ls /remote/path, got %s %q", got.Cmd, got.Path)
+	}
+
+	for name, want := range map[string]string{"test": "hello", "testa": "world"} {
+		content, err := os.ReadFile(filepath.Join(destDir, name))
+		if err != nil {
+			t.Fatalf("read %s from destination: %v", name, err)
+		}
+		if string(content) != want {
+			t.Errorf("unexpected content for %s: %q", name, content)
+		}
+	}
+	// Non-matching entries must not be downloaded anywhere.
+	if _, err := os.Stat(filepath.Join(localDir, "nope")); !os.IsNotExist(err) {
+		t.Errorf("expected no download for non-matching entry, stat err: %v", err)
+	}
+}
+
+// TestClientDoGetWildcardToTrailingSlashDir verifies that get with a glob
+// source and a slash-terminated destination treats the destination as a
+// directory even when it does not exist yet, creating it for the download.
+func TestClientDoGetWildcardToTrailingSlashDir(t *testing.T) {
+	localDir := t.TempDir()
+
+	ch := newMockChannel(
+		makeJSONDataMsg(&Response{OK: true, Entries: lsEntries("test")}),
+		makeJSONDataMsg(&Response{OK: true, Info: &FileInfo{Name: "test", Size: 5}}),
+		makeJSONDataMsg(&Response{OK: true, Data: []byte("hello")}),
+		makeJSONDataMsg(&Response{OK: true, Data: []byte{}}),
+	)
+
+	if err := doGet(ch, localDir, "/remote/path", []string{"get", "test*", "newdir/"}, nil); err != nil {
+		t.Fatalf("doGet error: %v", err)
+	}
+
+	content, err := os.ReadFile(filepath.Join(localDir, "newdir", "test"))
+	if err != nil {
+		t.Fatalf("read downloaded file: %v", err)
+	}
+	if string(content) != "hello" {
+		t.Fatalf("unexpected content: %q", content)
+	}
+}
+
+// TestClientDoGetWildcardSingleToFile verifies that a get whose glob source
+// matches a single entry and whose destination is not a directory uses the
+// destination as the downloaded file name verbatim.
+func TestClientDoGetWildcardSingleToFile(t *testing.T) {
+	localDir := t.TempDir()
+
+	ch := newMockChannel(
+		makeJSONDataMsg(&Response{OK: true, Entries: lsEntries("test")}),
+		makeJSONDataMsg(&Response{OK: true, Info: &FileInfo{Name: "test", Size: 5}}),
+		makeJSONDataMsg(&Response{OK: true, Data: []byte("hello")}),
+		makeJSONDataMsg(&Response{OK: true, Data: []byte{}}),
+	)
+
+	if err := doGet(ch, localDir, "/remote/path", []string{"get", "test*", "out.txt"}, nil); err != nil {
+		t.Fatalf("doGet error: %v", err)
+	}
+
+	content, err := os.ReadFile(filepath.Join(localDir, "out.txt"))
+	if err != nil {
+		t.Fatalf("read downloaded file: %v", err)
+	}
+	if string(content) != "hello" {
+		t.Fatalf("unexpected content: %q", content)
+	}
+}
+
+// TestClientDoGetWildcardMultiToNonDir verifies that a get whose glob source
+// matches multiple entries cannot target a file: the destination must be a
+// directory.
+func TestClientDoGetWildcardMultiToNonDir(t *testing.T) {
+	localDir := t.TempDir()
+
+	ch := newMockChannel(makeJSONDataMsg(&Response{OK: true, Entries: lsEntries("test", "testa")}))
+
+	err := doGet(ch, localDir, "/remote/path", []string{"get", "test*", "out.txt"}, nil)
+	if err == nil {
+		t.Fatal("expected error for multi-match get to non-directory")
+	}
+	if !strings.Contains(err.Error(), "not a directory") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+// TestClientDoGetToExistingLocalDir verifies that a non-glob get to an
+// existing local directory copies the remote file into it under its own
+// basename.
+func TestClientDoGetToExistingLocalDir(t *testing.T) {
+	localDir := t.TempDir()
+	destDir := filepath.Join(localDir, "dest")
+	os.MkdirAll(destDir, 0o755)
+
+	ch := newMockChannel(
+		makeJSONDataMsg(&Response{OK: true, Info: &FileInfo{Name: "remote.txt", Size: 5}}),
+		makeJSONDataMsg(&Response{OK: true, Data: []byte("hello")}),
+		makeJSONDataMsg(&Response{OK: true, Data: []byte{}}),
+	)
+
+	if err := doGet(ch, localDir, "/remote", []string{"get", "remote.txt", "dest"}, nil); err != nil {
+		t.Fatalf("doGet error: %v", err)
+	}
+
+	content, err := os.ReadFile(filepath.Join(destDir, "remote.txt"))
+	if err != nil {
+		t.Fatalf("read downloaded file: %v", err)
+	}
+	if string(content) != "hello" {
+		t.Fatalf("unexpected content: %q", content)
+	}
+}
+
+// TestClientDoGetToNewLocalName verifies that a non-glob get to a target that
+// is neither an existing directory nor slash-terminated uses the target as the
+// local file name verbatim.
+func TestClientDoGetToNewLocalName(t *testing.T) {
+	localDir := t.TempDir()
+
+	ch := newMockChannel(
+		makeJSONDataMsg(&Response{OK: true, Info: &FileInfo{Name: "remote.txt", Size: 5}}),
+		makeJSONDataMsg(&Response{OK: true, Data: []byte("hello")}),
+		makeJSONDataMsg(&Response{OK: true, Data: []byte{}}),
+	)
+
+	newName := filepath.Join(localDir, "newname")
+	if err := doGet(ch, localDir, "/remote", []string{"get", "remote.txt", "newname"}, nil); err != nil {
+		t.Fatalf("doGet error: %v", err)
+	}
+
+	content, err := os.ReadFile(newName)
+	if err != nil {
+		t.Fatalf("read downloaded file: %v", err)
+	}
+	if string(content) != "hello" {
+		t.Fatalf("unexpected content: %q", content)
+	}
+}
+
+// TestClientDoGetToAbsoluteTarget verifies that an absolute local destination
+// is used as-is rather than being joined onto the local working directory.
+func TestClientDoGetToAbsoluteTarget(t *testing.T) {
+	localDir := t.TempDir()
+	outDir := t.TempDir()
+	target := filepath.Join(outDir, "absolute.txt")
+
+	ch := newMockChannel(
+		makeJSONDataMsg(&Response{OK: true, Info: &FileInfo{Name: "remote.txt", Size: 5}}),
+		makeJSONDataMsg(&Response{OK: true, Data: []byte("hello")}),
+		makeJSONDataMsg(&Response{OK: true, Data: []byte{}}),
+	)
+
+	if err := doGet(ch, localDir, "/remote", []string{"get", "remote.txt", target}, nil); err != nil {
+		t.Fatalf("doGet error: %v", err)
+	}
+
+	content, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read downloaded file: %v", err)
+	}
+	if string(content) != "hello" {
+		t.Fatalf("unexpected content: %q", content)
+	}
+	if _, err := os.Stat(filepath.Join(localDir, "absolute.txt")); !os.IsNotExist(err) {
+		t.Errorf("expected file not to be placed under localDir, stat err: %v", err)
+	}
+}
+
 func TestResolveCDTarget(t *testing.T) {
 	const (
 		remoteDir = "/home/alice/work"


### PR DESCRIPTION
put now expands the local source against the filesystem with filepath.Glob (escaped metacharacters are matched literally), uploads every match under its basename, and honors a directory target for single and multiple sources. get now honors the local destination of a globbed source, placing matches in an existing or slash-terminated directory, using a single match as a file name, and erroring when multiple matches target a non-directory. Non-glob get destinations that name an existing local directory (or end with a separator) receive the file under its basename, and absolute local destinations are used as-is instead of being joined onto the local working directory.