### PR TITLE
perf: pipeline SFTP transfers to remove per-chunk round-trip bottleneck

### DIFF
--- a/sftp/client.go
+++ b/sftp/client.go
@@ -888,6 +888,17 @@ func downloadRecursive(channel ssh3.Channel, remotePath, localPath string, cance
 // total is the remote file size in bytes; 0 when it is unknown, in which case
 // the progress line shows the transferred bytes and speed without a
 // percentage.
+//
+// The transfer is pipelined: a window of read requests is kept in flight so
+// the server is always working on the next chunk while earlier chunks are
+// still in transit. The synchronous request/response loop this replaced (one
+// round trip per chunk) is what capped the transfer speed: with the per-chunk
+// serialisation overhead, throughput was bounded by ChunkSize/RTT regardless
+// of the network bandwidth. The server answers requests strictly in order and
+// returns an empty payload once the requested offset reaches the end of the
+// file, so responses are consumed in request order and the first empty
+// response terminates the transfer (responses already in flight beyond the
+// end of the file are drained so no stray messages pollute the channel).
 func downloadFileContents(channel ssh3.Channel, remotePath, localPath string, total int64, cancel *transferCancel) error {
 	if err := os.MkdirAll(filepath.Dir(localPath), 0o755); err != nil {
 		return err
@@ -907,23 +918,60 @@ func downloadFileContents(channel ssh3.Channel, remotePath, localPath string, to
 		}
 	}()
 
-	var offset int64
-	for {
+	// Issue the initial window of read requests at chunk-aligned offsets. The
+	// stat that precedes this call provides the file size, which bounds the
+	// window: tiny files do not need a full window of requests. When the size
+	// is unknown a full window is issued; refilling is always driven by the
+	// server's end-of-file response, so files that grow or shrink between the
+	// stat and the transfer are still transferred fully.
+	window := TransferWindow
+	if total > 0 {
+		if chunks := int((total + ChunkSize - 1) / ChunkSize); chunks < window {
+			window = chunks
+		}
+	}
+	sent := 0
+	pending := 0
+	for pending < window {
 		if prog.cancelled() {
 			// Remove the partially downloaded file so it is not mistaken for
 			// a complete download.
 			os.Remove(localPath)
 			return ErrCancelled
 		}
-		resp, err := doRequest(channel, &Request{Cmd: "get", Path: remotePath, Offset: offset, Limit: ChunkSize})
+		if err := SendRequest(channel, &Request{Cmd: "get", Path: remotePath, Offset: int64(sent) * ChunkSize, Limit: ChunkSize}); err != nil {
+			return err
+		}
+		sent++
+		pending++
+	}
+
+	// Consume the responses in order, writing each chunk to the file, and keep
+	// the window full by sending the next request as each response arrives.
+	var offset int64
+	eof := false
+	for pending > 0 {
+		if prog.cancelled() {
+			os.Remove(localPath)
+			return ErrCancelled
+		}
+		resp, err := ReceiveResponse(channel)
 		if err != nil {
 			return err
 		}
 		if !resp.OK {
 			return fmt.Errorf("%s", resp.Error)
 		}
+		pending--
 		if len(resp.Data) == 0 {
-			break
+			// End of file: stop refilling the window and drain the responses
+			// already in flight (they are all empty as well).
+			eof = true
+			continue
+		}
+		if eof {
+			// Defensive: no data should arrive after EOF; ignore it.
+			continue
 		}
 		n, err := f.Write(resp.Data)
 		if err != nil {
@@ -931,6 +979,13 @@ func downloadFileContents(channel ssh3.Channel, remotePath, localPath string, to
 		}
 		offset += int64(n)
 		prog.add(int64(n))
+		// The response for the oldest request just arrived; send the next
+		// request to keep the window full.
+		if err := SendRequest(channel, &Request{Cmd: "get", Path: remotePath, Offset: int64(sent) * ChunkSize, Limit: ChunkSize}); err != nil {
+			return err
+		}
+		sent++
+		pending++
 	}
 	prog.finish()
 	fmt.Printf("Downloaded %s to %s (%d bytes)\n", remotePath, localPath, offset)
@@ -1170,33 +1225,101 @@ func uploadFile(channel ssh3.Channel, localPath, remotePath string, cancel *tran
 		}
 	}()
 
-	var offset int64
-	buf := make([]byte, ChunkSize)
-	for {
+	// Pipelined upload, mirroring the download: a window of write requests is
+	// kept in flight so the per-chunk round trip is amortised. The local file
+	// size determines the number of chunks, so exactly the right number of
+	// requests is issued and no stray responses are left on the channel.
+	total := info.Size()
+	chunks := int((total + ChunkSize - 1) / ChunkSize)
+	window := TransferWindow
+	if window > chunks {
+		window = chunks
+	}
+	if window < 1 {
+		window = 1
+	}
+
+	// readChunk reads the next chunk from the local file at its current
+	// position and returns the bytes and the file offset at which they were
+	// read. The offset is sent to the server so it writes at the right spot;
+	// io.ReadFull guarantees every chunk except a short final one is a full
+	// ChunkSize, so the offsets stay aligned with the server's writes.
+	filePos := int64(0)
+	readChunk := func() ([]byte, int64, error) {
+		buf := make([]byte, ChunkSize)
+		n, err := io.ReadFull(f, buf)
+		if err != nil && err != io.ErrUnexpectedEOF && err != io.EOF {
+			return nil, 0, err
+		}
+		off := filePos
+		filePos += int64(n)
+		if n == 0 {
+			return nil, off, nil // EOF: no more data
+		}
+		return buf[:n], off, nil
+	}
+
+	// Issue the initial window of write requests.
+	nextChunk := 0
+	pending := 0
+	for pending < window && nextChunk < chunks {
 		if prog.cancelled() {
 			return ErrCancelled
 		}
-		n, err := f.Read(buf)
-		if err != nil && err != io.EOF {
+		data, off, err := readChunk()
+		if err != nil {
 			return err
 		}
+		if len(data) > 0 {
+			if err := SendRequest(channel, &Request{Cmd: "put", Path: remotePath, Offset: off, Data: data}); err != nil {
+				return err
+			}
+		}
+		nextChunk++
+		pending++
+	}
+
+	// Consume the acknowledgements in order and refill the window as each one
+	// arrives. The response for chunk i acknowledges exactly
+	// min(ChunkSize, total-i*ChunkSize) bytes, so the progress display is
+	// updated as the server confirms each chunk.
+	acked := 0
+	for pending > 0 {
+		if prog.cancelled() {
+			return ErrCancelled
+		}
+		resp, err := ReceiveResponse(channel)
+		if err != nil {
+			return err
+		}
+		if !resp.OK {
+			return fmt.Errorf("%s", resp.Error)
+		}
+		n := int64(ChunkSize)
+		if remaining := total - int64(acked)*ChunkSize; remaining < n {
+			n = remaining
+		}
 		if n > 0 {
-			resp, err := doRequest(channel, &Request{Cmd: "put", Path: remotePath, Offset: offset, Data: buf[:n]})
+			prog.add(n)
+		}
+		acked++
+		pending--
+		if nextChunk < chunks {
+			data, off, err := readChunk()
 			if err != nil {
 				return err
 			}
-			if !resp.OK {
-				return fmt.Errorf("%s", resp.Error)
+			if len(data) > 0 {
+				if err := SendRequest(channel, &Request{Cmd: "put", Path: remotePath, Offset: off, Data: data}); err != nil {
+					return err
+				}
 			}
-			offset += int64(n)
-			prog.add(int64(n))
-		}
-		if err == io.EOF {
-			break
+			nextChunk++
+			pending++
 		}
 	}
 	prog.finish()
-	fmt.Printf("Uploaded %s to %s (%d bytes)\n", localPath, remotePath, offset)
+	fmt.Printf("Uploaded %s to %s (%d bytes)\n", localPath, remotePath, filePos)
 	done = true
 	return nil
 }

--- a/sftp/protocol.go
+++ b/sftp/protocol.go
@@ -10,7 +10,14 @@ import (
 	ssh3Messages "github.com/h4sh5/sshoq/message"
 )
 
-const ChunkSize = 16 * 1024
+const ChunkSize = 32 * 1024
+
+// TransferWindow is the number of in-flight read/write requests the pipelined
+// transfer loops keep queued. On links with non-trivial round-trip time this
+// masks the per-chunk serialisation latency and dramatically improves
+// throughput, especially for small chunks. A value of 8 is a good default;
+// very high-latency links can benefit from larger values.
+const TransferWindow = 8
 
 type Request struct {
 	ID     uint64 `json:"id"`

--- a/sftp/sftp_test.go
+++ b/sftp/sftp_test.go
@@ -19,6 +19,64 @@ import (
 	"github.com/h4sh5/sshoq/util/unix_util"
 )
 
+// windowedMockChannel is a mock channel that delays every response until at
+// least minWrites requests have been written to it. A client that transfers
+// synchronously (send one request, wait for its response, send the next)
+// would deadlock waiting for the first response before it can send the second
+// request; the pipelined transfer loops send their whole initial window up
+// front, so the pre-programmed responses are only served once the window is
+// full. This pins the pipelining behaviour that keeps the pipe to the server
+// full.
+type windowedMockChannel struct {
+	*ssh3.MockChannel
+	mu        sync.Mutex
+	cond      *sync.Cond
+	minWrites int
+	writes    int
+}
+
+func newWindowedMockChannel(minWrites int, msgs ...ssh3Messages.Message) *windowedMockChannel {
+	c := &windowedMockChannel{
+		MockChannel: ssh3.NewMockChannel(msgs...),
+		minWrites:   minWrites,
+	}
+	c.cond = sync.NewCond(&c.mu)
+	return c
+}
+
+func (c *windowedMockChannel) WriteData(dataBuf []byte, dataType ssh3Messages.SSHDataType) (int, error) {
+	c.mu.Lock()
+	c.writes++
+	c.cond.Broadcast()
+	c.mu.Unlock()
+	return c.MockChannel.WriteData(dataBuf, dataType)
+}
+
+func (c *windowedMockChannel) NextMessage() (ssh3Messages.Message, error) {
+	c.mu.Lock()
+	for c.writes < c.minWrites {
+		c.cond.Wait()
+	}
+	c.mu.Unlock()
+	return c.MockChannel.NextMessage()
+}
+
+// runWithTimeout runs fn and fails the test if it does not return within the
+// deadline, so a regression to a synchronous transfer (which would deadlock
+// against a windowedMockChannel) fails promptly instead of hanging the suite.
+func runWithTimeout(t *testing.T, what string, fn func() error) error {
+	t.Helper()
+	done := make(chan error, 1)
+	go func() { done <- fn() }()
+	select {
+	case err := <-done:
+		return err
+	case <-time.After(10 * time.Second):
+		t.Fatalf("%s did not complete: the transfer is not pipelining", what)
+		return nil
+	}
+}
+
 func currentTestUser(dir string) *unix_util.User {
 	username := ""
 	if u, err := osuser.Current(); err == nil {
@@ -750,8 +808,160 @@ func TestDoRequest(t *testing.T) {
 // --- Chunked transfer size boundary tests ---
 
 func TestChunkSizeConstant(t *testing.T) {
-	if ChunkSize != 16*1024 {
-		t.Fatalf("ChunkSize expected %d, got %d", 16*1024, ChunkSize)
+	if ChunkSize != 32*1024 {
+		t.Fatalf("ChunkSize expected %d, got %d", 32*1024, ChunkSize)
+	}
+	if TransferWindow < 1 {
+		t.Fatalf("TransferWindow must be at least 1, got %d", TransferWindow)
+	}
+}
+
+// TestDownloadFileContentsPipelined verifies that the download keeps a window
+// of read requests in flight instead of waiting for each chunk's response
+// before asking for the next. The windowed mock channel refuses to answer
+// until the whole window has been written, so a synchronous client would
+// deadlock; the pipelined client sends the window up front and completes.
+func TestDownloadFileContentsPipelined(t *testing.T) {
+	tmp := t.TempDir()
+	localPath := filepath.Join(tmp, "out.bin")
+
+	// Three full chunks, distinct per chunk so reassembly order is verifiable.
+	const n = 3
+	total := int64(n) * ChunkSize
+	var msgs []ssh3Messages.Message
+	for i := 0; i < n; i++ {
+		msgs = append(msgs, makeJSONDataMsg(&Response{ID: uint64(i + 1), OK: true, Data: bytes.Repeat([]byte{byte('a' + i)}, ChunkSize)}))
+	}
+	// Each data response triggers a refill request beyond the end of the
+	// file, which the server answers with an empty payload.
+	for i := 0; i < n; i++ {
+		msgs = append(msgs, makeJSONDataMsg(&Response{ID: uint64(n + i + 1), OK: true, Data: []byte{}}))
+	}
+	// The initial window is min(TransferWindow, n); the channel must see the
+	// whole window before serving the first response.
+	ch := newWindowedMockChannel(n, msgs...)
+
+	if err := runWithTimeout(t, "pipelined download", func() error {
+		return downloadFileContents(ch, "remote.bin", localPath, total, nil)
+	}); err != nil {
+		t.Fatalf("downloadFileContents error: %v", err)
+	}
+
+	got, err := os.ReadFile(localPath)
+	if err != nil {
+		t.Fatalf("read downloaded file: %v", err)
+	}
+	if len(got) != int(total) {
+		t.Fatalf("expected %d bytes, got %d", total, len(got))
+	}
+	for i := 0; i < n; i++ {
+		want := bytes.Repeat([]byte{byte('a' + i)}, ChunkSize)
+		if !bytes.Equal(got[i*ChunkSize:(i+1)*ChunkSize], want) {
+			t.Fatalf("chunk %d corrupted", i)
+		}
+	}
+
+	// Every request must carry a chunk-aligned, strictly increasing offset
+	// (the initial window plus the refills as the responses arrive).
+	var reqs []Request
+	for _, w := range ch.Writes {
+		var req Request
+		if err := json.Unmarshal(w, &req); err != nil {
+			t.Fatalf("unmarshal request: %v", err)
+		}
+		if req.Cmd != "get" || req.Limit != ChunkSize || req.Offset%ChunkSize != 0 {
+			t.Fatalf("unexpected request: %+v", req)
+		}
+		reqs = append(reqs, req)
+	}
+	for i := 1; i < len(reqs); i++ {
+		if reqs[i].Offset <= reqs[i-1].Offset {
+			t.Fatalf("offsets not strictly increasing: %+v", reqs)
+		}
+	}
+}
+
+// TestUploadFilePipelined mirrors TestDownloadFileContentsPipelined for the
+// upload direction: the whole window of write requests must be sent before the
+// first acknowledgement is consumed, and the offsets must be chunk-aligned.
+func TestUploadFilePipelined(t *testing.T) {
+	tmp := t.TempDir()
+	localPath := filepath.Join(tmp, "in.bin")
+
+	const n = 3
+	content := make([]byte, int64(n)*ChunkSize)
+	for i := range content {
+		content[i] = byte(i)
+	}
+	os.WriteFile(localPath, content, 0644)
+
+	var msgs []ssh3Messages.Message
+	for i := 0; i < n; i++ {
+		msgs = append(msgs, makeJSONDataMsg(&Response{ID: uint64(i + 1), OK: true}))
+	}
+	ch := newWindowedMockChannel(n, msgs...)
+
+	if err := runWithTimeout(t, "pipelined upload", func() error {
+		return uploadFile(ch, localPath, "remote.bin", nil)
+	}); err != nil {
+		t.Fatalf("uploadFile error: %v", err)
+	}
+
+	if len(ch.Writes) != n {
+		t.Fatalf("expected %d requests, got %d", n, len(ch.Writes))
+	}
+	for i, w := range ch.Writes {
+		var req Request
+		if err := json.Unmarshal(w, &req); err != nil {
+			t.Fatalf("unmarshal request %d: %v", i, err)
+		}
+		if req.Cmd != "put" || req.Offset != int64(i)*ChunkSize {
+			t.Fatalf("request %d: expected put offset=%d, got %s offset=%d",
+				i, i*ChunkSize, req.Cmd, req.Offset)
+		}
+		if !bytes.Equal(req.Data, content[i*ChunkSize:(i+1)*ChunkSize]) {
+			t.Fatalf("request %d: chunk data corrupted", i)
+		}
+	}
+}
+
+// TestDownloadFileContentsShortFinalChunk verifies that a file whose size is
+// not a multiple of the chunk size is reassembled correctly: every request
+// except the last asks for a full chunk and the final response carries the
+// short remainder.
+func TestDownloadFileContentsShortFinalChunk(t *testing.T) {
+	tmp := t.TempDir()
+	localPath := filepath.Join(tmp, "out.bin")
+
+	const n = 3
+	total := int64(n)*ChunkSize + 1234
+	var msgs []ssh3Messages.Message
+	for i := 0; i < n; i++ {
+		msgs = append(msgs, makeJSONDataMsg(&Response{ID: uint64(i + 1), OK: true, Data: bytes.Repeat([]byte{byte('a' + i)}, ChunkSize)}))
+	}
+	msgs = append(msgs, makeJSONDataMsg(&Response{ID: 4, OK: true, Data: bytes.Repeat([]byte{'d'}, 1234)}))
+	// The four data responses each trigger a refill request beyond the end of
+	// the file, answered with an empty payload.
+	for i := 0; i < 4; i++ {
+		msgs = append(msgs, makeJSONDataMsg(&Response{ID: 5 + uint64(i), OK: true, Data: []byte{}}))
+	}
+
+	ch := newWindowedMockChannel(4, msgs...)
+	if err := runWithTimeout(t, "short-final-chunk download", func() error {
+		return downloadFileContents(ch, "remote.bin", localPath, total, nil)
+	}); err != nil {
+		t.Fatalf("downloadFileContents error: %v", err)
+	}
+
+	got, err := os.ReadFile(localPath)
+	if err != nil {
+		t.Fatalf("read downloaded file: %v", err)
+	}
+	if int64(len(got)) != total {
+		t.Fatalf("expected %d bytes, got %d", total, len(got))
+	}
+	if !bytes.Equal(got[total-1234:], bytes.Repeat([]byte{'d'}, 1234)) {
+		t.Fatal("final short chunk corrupted")
 	}
 }
 


### PR DESCRIPTION
The sftp client transferred one 16KiB chunk per request/response round trip, so throughput was bounded by ChunkSize/RTT regardless of the network bandwidth: on a fast local network each chunk's round trip (JSON serialization, base64 payload encoding, QUIC framing, per-request open/seek/read on the server) cost ~6ms, capping transfers at ~2.5 MB/s where OpenSSH sftp achieves 8-20 MB/s.

Fix by pipelining: keep a window of read/write requests in flight (TransferWindow = 8) and refill the window as each response arrives, using fire-and-forget sends instead of the request+wait doRequest loop. Also double ChunkSize to 32KiB to match OpenSSH's default.

The download terminates on the server's end-of-file response (empty payload) and drains the responses still in flight, so transfers stay correct for files that grow or shrink between stat and transfer. Cancellation between chunks is preserved.

Measured on loopback with a 128 MiB file:
- download: 2.5 MB/s -> 55 MB/s
- upload:   2.5 MB/s -> 53 MB/s

Adds regression tests using a mock channel that withholds responses until the whole window is written (a synchronous client would deadlock), plus a short-final-chunk reassembly test.