### PR TITLE
fix: include filepath in all sftp client/server error messages

### DIFF
--- a/sftp/client.go
+++ b/sftp/client.go
@@ -292,7 +292,7 @@ func newCompleter(channel ssh3.Channel, localDir, remoteDir *string) completeFun
 			return nil, err
 		}
 		if !resp.OK {
-			return nil, fmt.Errorf("%s", resp.Error)
+			return nil, serverError(dir, resp.Error)
 		}
 		names := make([]string, 0, len(resp.Entries))
 		for _, e := range resp.Entries {
@@ -497,7 +497,7 @@ func doLs(channel ssh3.Channel, remoteDir string, parts []string) error {
 		return err
 	}
 	if !resp.OK {
-		return fmt.Errorf("%s", resp.Error)
+		return serverError(listDir, resp.Error)
 	}
 
 	entries := resp.Entries
@@ -591,7 +591,7 @@ func doGet(channel ssh3.Channel, localDir, remoteDir string, parts []string, can
 			return err
 		}
 		if !resp.OK {
-			return fmt.Errorf("%s", resp.Error)
+			return serverError(sourceDir, resp.Error)
 		}
 		var matched []FileInfo
 		for _, e := range resp.Entries {
@@ -849,7 +849,7 @@ func downloadRecursive(channel ssh3.Channel, remotePath, localPath string, cance
 		return err
 	}
 	if !statResp.OK {
-		return fmt.Errorf("%s", statResp.Error)
+		return serverError(remotePath, statResp.Error)
 	}
 	if statResp.Info != nil && statResp.Info.IsDir {
 		if err := os.MkdirAll(localPath, 0o755); err != nil {
@@ -860,7 +860,7 @@ func downloadRecursive(channel ssh3.Channel, remotePath, localPath string, cance
 			return err
 		}
 		if !resp.OK {
-			return fmt.Errorf("%s", resp.Error)
+			return serverError(remotePath, resp.Error)
 		}
 		for _, entry := range resp.Entries {
 			childRemote := path.Join(remotePath, entry.Name)
@@ -960,7 +960,7 @@ func downloadFileContents(channel ssh3.Channel, remotePath, localPath string, to
 			return err
 		}
 		if !resp.OK {
-			return fmt.Errorf("%s", resp.Error)
+			return serverError(remotePath, resp.Error)
 		}
 		pending--
 		if len(resp.Data) == 0 {
@@ -1068,7 +1068,7 @@ func ensureRemoteDir(channel ssh3.Channel, remotePath string) error {
 		return err
 	}
 	if !mkdirResp.OK {
-		return fmt.Errorf("%s", mkdirResp.Error)
+		return serverError(remotePath, mkdirResp.Error)
 	}
 	return nil
 }
@@ -1183,16 +1183,34 @@ func doRequest(channel ssh3.Channel, req *Request) (*Response, error) {
 	return ReceiveResponse(channel)
 }
 
+// serverError converts a non-OK server response into an error that names the
+// filepath it concerns. Servers normally include the path in their error
+// messages (any absolute path contains a "/"), but messages without one are
+// prefixed with the path known to the client so errors like "too many levels
+// of symbolic links" identify the file involved.
+func serverError(path, msg string) error {
+	if msg == "" {
+		msg = "unknown error"
+	}
+	if path == "" || path == "." || path == "/" {
+		return errors.New(msg)
+	}
+	if strings.Contains(msg, "/") || strings.Contains(msg, path) {
+		return errors.New(msg)
+	}
+	return fmt.Errorf("%s: %s", path, msg)
+}
+
 func downloadFile(channel ssh3.Channel, remotePath, localPath string, cancel *transferCancel) error {
 	statResp, err := doRequest(channel, &Request{Cmd: "stat", Path: remotePath})
 	if err != nil {
 		return err
 	}
 	if !statResp.OK {
-		return fmt.Errorf("%s", statResp.Error)
+		return serverError(remotePath, statResp.Error)
 	}
 	if statResp.Info != nil && statResp.Info.IsDir {
-		return fmt.Errorf("cannot download a directory")
+		return fmt.Errorf("cannot download a directory: %s", remotePath)
 	}
 
 	var total int64
@@ -1214,7 +1232,7 @@ func uploadFile(channel ssh3.Channel, localPath, remotePath string, cancel *tran
 		return err
 	}
 	if info.IsDir() {
-		return fmt.Errorf("cannot upload a directory")
+		return fmt.Errorf("cannot upload a directory: %s", localPath)
 	}
 
 	prog := newProgress(filepath.Base(localPath), info.Size(), os.Stdout, cancel)
@@ -1293,7 +1311,7 @@ func uploadFile(channel ssh3.Channel, localPath, remotePath string, cancel *tran
 			return err
 		}
 		if !resp.OK {
-			return fmt.Errorf("%s", resp.Error)
+			return serverError(remotePath, resp.Error)
 		}
 		n := int64(ChunkSize)
 		if remaining := total - int64(acked)*ChunkSize; remaining < n {

--- a/sftp/server.go
+++ b/sftp/server.go
@@ -225,6 +225,15 @@ func (s *ServerSession) resolvePath(p string) string {
 	return filepath.Join(s.currentDir, p)
 }
 
+// pathErr wraps err with the path it concerns so that syscall-level errors
+// such as "too many levels of symbolic links" identify the file involved.
+func pathErr(path string, err error) error {
+	if err == nil {
+		return nil
+	}
+	return fmt.Errorf("%s: %w", path, err)
+}
+
 func (s *ServerSession) handleRequest(req Request) *Response {
 	resp := &Response{ID: req.ID}
 	target := s.resolvePath(req.Path)
@@ -242,13 +251,13 @@ func (s *ServerSession) handleRequest(req Request) *Response {
 		dirfd, pathArg := s.dirFDAndPath(req.Path, target)
 		fd, err := unix.Openat(dirfd, pathArg, unix.O_RDONLY|unix.O_DIRECTORY|unix.O_NOFOLLOW|unix.O_CLOEXEC, 0)
 		if err != nil {
-			resp.Error = err.Error()
+			resp.Error = pathErr(target, err).Error()
 			break
 		}
 		defer unix.Close(fd)
 
 		if err := s.checkFDPermission(fd, accessR|accessX); err != nil {
-			resp.Error = fmt.Sprintf("permission denied: %s", err)
+			resp.Error = pathErr(target, err).Error()
 			break
 		}
 
@@ -266,25 +275,25 @@ func (s *ServerSession) handleRequest(req Request) *Response {
 		dirfd, pathArg := s.dirFDAndPath(req.Path, target)
 		fd, err := unix.Openat(dirfd, pathArg, unix.O_RDONLY|unix.O_DIRECTORY|unix.O_NOFOLLOW|unix.O_CLOEXEC, 0)
 		if err != nil {
-			resp.Error = err.Error()
+			resp.Error = pathErr(target, err).Error()
 			break
 		}
 		file := os.NewFile(uintptr(fd), target)
 		if file == nil {
 			unix.Close(fd)
-			resp.Error = "failed to open directory"
+			resp.Error = fmt.Sprintf("%s: failed to open directory", target)
 			break
 		}
 		defer file.Close()
 
 		if err := s.checkFDPermission(fd, accessR|accessX); err != nil {
-			resp.Error = fmt.Sprintf("permission denied: %s", err)
+			resp.Error = pathErr(target, err).Error()
 			break
 		}
 
 		entries, err := file.ReadDir(-1)
 		if err != nil {
-			resp.Error = err.Error()
+			resp.Error = pathErr(target, err).Error()
 			break
 		}
 
@@ -335,26 +344,26 @@ func (s *ServerSession) handleRequest(req Request) *Response {
 		dirfd, pathArg := s.dirFDAndPath(req.Path, target)
 		fd, err := unix.Openat(dirfd, pathArg, unix.O_RDONLY|unix.O_NOFOLLOW|unix.O_CLOEXEC, 0)
 		if err != nil {
-			resp.Error = err.Error()
+			resp.Error = pathErr(target, err).Error()
 			break
 		}
 		file := os.NewFile(uintptr(fd), target)
 		if file == nil {
 			unix.Close(fd)
-			resp.Error = "failed to open file"
+			resp.Error = fmt.Sprintf("%s: failed to open file", target)
 			break
 		}
 		defer file.Close()
 
 		if err := s.checkFDPermission(fd, accessR); err != nil {
-			resp.Error = fmt.Sprintf("permission denied: %s", err)
+			resp.Error = pathErr(target, err).Error()
 			break
 		}
 
 		if req.Offset > 0 {
 			_, err = file.Seek(req.Offset, io.SeekStart)
 			if err != nil {
-				resp.Error = err.Error()
+				resp.Error = pathErr(target, err).Error()
 				break
 			}
 		}
@@ -367,7 +376,7 @@ func (s *ServerSession) handleRequest(req Request) *Response {
 		buf := make([]byte, limit)
 		n, err := file.Read(buf)
 		if err != nil && err != io.EOF {
-			resp.Error = err.Error()
+			resp.Error = pathErr(target, err).Error()
 			break
 		}
 		resp.OK = true
@@ -380,7 +389,7 @@ func (s *ServerSession) handleRequest(req Request) *Response {
 		}
 		parentFd, name, err := s.openParentDir(req.Path, target)
 		if err != nil {
-			resp.Error = err.Error()
+			resp.Error = pathErr(target, err).Error()
 			break
 		}
 		defer unix.Close(parentFd)
@@ -389,17 +398,17 @@ func (s *ServerSession) handleRequest(req Request) *Response {
 		statErr := unix.Fstatat(parentFd, name, &st, unix.AT_SYMLINK_NOFOLLOW)
 		isNewFile := statErr == syscall.ENOENT
 		if statErr != nil && !isNewFile {
-			resp.Error = statErr.Error()
+			resp.Error = pathErr(target, statErr).Error()
 			break
 		}
 
 		if isNewFile {
 			if err := s.checkFDPermission(parentFd, accessW|accessX); err != nil {
-				resp.Error = fmt.Sprintf("permission denied: %s", err)
+				resp.Error = pathErr(target, err).Error()
 				break
 			}
 		} else if st.Mode&unix.S_IFMT == unix.S_IFDIR {
-			resp.Error = "is a directory"
+			resp.Error = fmt.Sprintf("%s: is a directory", target)
 			break
 		}
 
@@ -413,33 +422,33 @@ func (s *ServerSession) handleRequest(req Request) *Response {
 
 		fd, err := unix.Openat(parentFd, name, flags, 0644)
 		if err != nil {
-			resp.Error = err.Error()
+			resp.Error = pathErr(target, err).Error()
 			break
 		}
 		file := os.NewFile(uintptr(fd), target)
 		if file == nil {
 			unix.Close(fd)
-			resp.Error = "failed to open file"
+			resp.Error = fmt.Sprintf("%s: failed to open file", target)
 			break
 		}
 		defer file.Close()
 
 		if err := s.checkFDPermission(fd, accessW); err != nil {
-			resp.Error = fmt.Sprintf("permission denied: %s", err)
+			resp.Error = pathErr(target, err).Error()
 			break
 		}
 
 		if req.Offset > 0 {
 			_, err = file.Seek(req.Offset, io.SeekStart)
 			if err != nil {
-				resp.Error = err.Error()
+				resp.Error = pathErr(target, err).Error()
 				break
 			}
 		}
 
 		_, err = file.Write(req.Data)
 		if err != nil {
-			resp.Error = err.Error()
+			resp.Error = pathErr(target, err).Error()
 		} else {
 			resp.OK = true
 		}
@@ -451,13 +460,13 @@ func (s *ServerSession) handleRequest(req Request) *Response {
 		}
 		parentFd, name, err := s.openParentDir(req.Path, target)
 		if err != nil {
-			resp.Error = err.Error()
+			resp.Error = pathErr(target, err).Error()
 			break
 		}
 		defer unix.Close(parentFd)
 
 		if err := s.checkFDPermission(parentFd, accessW|accessX); err != nil {
-			resp.Error = fmt.Sprintf("permission denied: %s", err)
+			resp.Error = pathErr(target, err).Error()
 			break
 		}
 
@@ -466,13 +475,13 @@ func (s *ServerSession) handleRequest(req Request) *Response {
 			resp.Error = fmt.Sprintf("%s already exists", target)
 			break
 		} else if err != syscall.ENOENT {
-			resp.Error = err.Error()
+			resp.Error = pathErr(target, err).Error()
 			break
 		}
 
 		err = unix.Mkdirat(parentFd, name, 0755)
 		if err != nil {
-			resp.Error = err.Error()
+			resp.Error = pathErr(target, err).Error()
 		} else {
 			resp.OK = true
 		}
@@ -484,19 +493,19 @@ func (s *ServerSession) handleRequest(req Request) *Response {
 		}
 		parentFd, name, err := s.openParentDir(req.Path, target)
 		if err != nil {
-			resp.Error = err.Error()
+			resp.Error = pathErr(target, err).Error()
 			break
 		}
 		defer unix.Close(parentFd)
 
 		if err := s.checkFDPermission(parentFd, accessW|accessX); err != nil {
-			resp.Error = fmt.Sprintf("permission denied: %s", err)
+			resp.Error = pathErr(target, err).Error()
 			break
 		}
 
 		err = unix.Unlinkat(parentFd, name, 0)
 		if err != nil {
-			resp.Error = err.Error()
+			resp.Error = pathErr(target, err).Error()
 		} else {
 			resp.OK = true
 		}
@@ -508,19 +517,19 @@ func (s *ServerSession) handleRequest(req Request) *Response {
 		}
 		parentFd, name, err := s.openParentDir(req.Path, target)
 		if err != nil {
-			resp.Error = err.Error()
+			resp.Error = pathErr(target, err).Error()
 			break
 		}
 		defer unix.Close(parentFd)
 
 		if err := s.checkFDPermission(parentFd, accessW|accessX); err != nil {
-			resp.Error = fmt.Sprintf("permission denied: %s", err)
+			resp.Error = pathErr(target, err).Error()
 			break
 		}
 
 		err = unix.Unlinkat(parentFd, name, unix.AT_REMOVEDIR)
 		if err != nil {
-			resp.Error = err.Error()
+			resp.Error = pathErr(target, err).Error()
 		} else {
 			resp.OK = true
 		}
@@ -540,7 +549,7 @@ func (s *ServerSession) statPath(rawPath, resolvedPath string) (*unix.Stat_t, er
 
 	var st unix.Stat_t
 	if err := unix.Fstatat(dirfd, pathArg, &st, unix.AT_SYMLINK_NOFOLLOW); err != nil {
-		return nil, err
+		return nil, pathErr(resolvedPath, err)
 	}
 
 	return &st, nil
@@ -648,10 +657,10 @@ func (s *ServerSession) checkAncestorExecute(path string) error {
 	if filepath.IsAbs(clean) {
 		var rootSt syscall.Stat_t
 		if err := syscall.Stat(string(filepath.Separator), &rootSt); err != nil {
-			return err
+			return pathErr(string(filepath.Separator), err)
 		}
 		if err := s.checkStatPermission(rootSt.Uid, rootSt.Gid, uint32(rootSt.Mode), accessX); err != nil {
-			return fmt.Errorf("permission denied: %w", err)
+			return pathErr(string(filepath.Separator), err)
 		}
 	}
 
@@ -680,13 +689,13 @@ func (s *ServerSession) checkAncestorExecute(path string) error {
 
 		var st syscall.Stat_t
 		if err := syscall.Stat(current, &st); err != nil {
-			return err
+			return pathErr(current, err)
 		}
 		if (st.Mode & syscall.S_IFMT) != syscall.S_IFDIR {
-			return syscall.ENOTDIR
+			return pathErr(current, syscall.ENOTDIR)
 		}
 		if err := s.checkStatPermission(st.Uid, st.Gid, uint32(st.Mode), accessX); err != nil {
-			return fmt.Errorf("permission denied: %w", err)
+			return pathErr(current, err)
 		}
 	}
 

--- a/sftp/sftp_test.go
+++ b/sftp/sftp_test.go
@@ -252,7 +252,7 @@ func TestServerHandleRequest_cdNotDir(t *testing.T) {
 
 	sess := &ServerSession{currentDir: tmp}
 	resp := sess.handleRequest(Request{Cmd: "cd", Path: "file.txt"})
-	if resp.OK || resp.Error != "not a directory" {
+	if resp.OK || !strings.Contains(resp.Error, "not a directory") {
 		t.Fatalf("unexpected response: %+v", resp)
 	}
 }
@@ -690,6 +690,48 @@ func TestDownloadFile_StatFail(t *testing.T) {
 	}
 }
 
+// TestDownloadFile_ServerErrorIncludesPath verifies that a server error
+// reported without a path is enriched with the remote path on the client, so
+// errors like "too many levels of symbolic links" identify the file.
+func TestDownloadFile_ServerErrorIncludesPath(t *testing.T) {
+	ch := newMockChannel(makeJSONDataMsg(&Response{ID: 1, OK: false, Error: "too many levels of symbolic links"}))
+	err := downloadFile(ch, "loop/file.txt", filepath.Join(t.TempDir(), "out"), nil)
+	if err == nil {
+		t.Fatal("expected error from server")
+	}
+	if !strings.Contains(err.Error(), "loop/file.txt") {
+		t.Fatalf("expected error to include the remote path, got: %v", err)
+	}
+}
+
+// TestDownloadFile_ServerErrorWithPathNotDuplicated verifies that a server
+// error that already carries the path is passed through unchanged.
+func TestDownloadFile_ServerErrorWithPathNotDuplicated(t *testing.T) {
+	const serverErr = "/remote/loop/file.txt: too many levels of symbolic links"
+	ch := newMockChannel(makeJSONDataMsg(&Response{ID: 1, OK: false, Error: serverErr}))
+	err := downloadFile(ch, "/remote/loop/file.txt", filepath.Join(t.TempDir(), "out"), nil)
+	if err == nil || err.Error() != serverErr {
+		t.Fatalf("expected unchanged server error, got: %v", err)
+	}
+}
+
+// TestUploadFile_ServerErrorIncludesPath verifies that an upload rejection by
+// the server is reported with the remote path it concerned.
+func TestUploadFile_ServerErrorIncludesPath(t *testing.T) {
+	tmp := t.TempDir()
+	localPath := filepath.Join(tmp, "local.txt")
+	os.WriteFile(localPath, []byte("x"), 0644)
+
+	ch := newMockChannel(makeJSONDataMsg(&Response{ID: 1, OK: false, Error: "too many levels of symbolic links"}))
+	err := uploadFile(ch, localPath, "loop/out.txt", nil)
+	if err == nil {
+		t.Fatal("expected error from server")
+	}
+	if !strings.Contains(err.Error(), "loop/out.txt") {
+		t.Fatalf("expected error to include the remote path, got: %v", err)
+	}
+}
+
 func TestUploadFile(t *testing.T) {
 	tmp := t.TempDir()
 	localPath := filepath.Join(tmp, "local.txt")
@@ -777,7 +819,7 @@ func TestUploadFile_DirectoryError(t *testing.T) {
 
 	ch := newMockChannel()
 	err := uploadFile(ch, dirPath, "/remote/file", nil)
-	if err == nil || err.Error() != "cannot upload a directory" {
+	if err == nil || !strings.Contains(err.Error(), "cannot upload a directory") {
 		t.Fatalf("expected directory upload error, got: %v", err)
 	}
 }
@@ -1089,6 +1131,90 @@ func TestServerHandleRequest_lsMissing(t *testing.T) {
 	resp := sess.handleRequest(Request{Cmd: "ls", Path: "missing"})
 	if resp.OK || resp.Error == "" {
 		t.Fatalf("expected error for missing dir, got %+v", resp)
+	}
+}
+
+// TestServerHandleRequest_symlinkLoopIncludesPath verifies that syscall errors
+// such as ELOOP ("too many levels of symbolic links") identify the filepath
+// that caused them, both when the loop sits in an ancestor directory
+// (checkAncestorExecute) and when the request target itself is the loop.
+func TestServerHandleRequest_symlinkLoopIncludesPath(t *testing.T) {
+	tmp := t.TempDir()
+	loop := filepath.Join(tmp, "loop")
+	if err := os.Mkdir(loop, 0755); err != nil {
+		t.Fatalf("mkdir failed: %v", err)
+	}
+	if err := os.Symlink("loop", filepath.Join(loop, "loop")); err != nil {
+		t.Skipf("cannot create symlink: %v", err)
+	}
+
+	sess := &ServerSession{currentDir: tmp}
+	loopPath := filepath.Join(loop, "loop")
+
+	// The ancestor tmp/loop/loop is a symlink loop: checkAncestorExecute
+	// fails while traversing it and must report the path that failed.
+	resp := sess.handleRequest(Request{Cmd: "ls", Path: "loop/loop/loop"})
+	if resp.OK || resp.Error == "" {
+		t.Fatalf("expected symlink loop error, got %+v", resp)
+	}
+	if !strings.Contains(resp.Error, loopPath) {
+		t.Fatalf("expected error to include path %s, got %q", loopPath, resp.Error)
+	}
+	if !strings.Contains(resp.Error, "symbolic links") {
+		t.Fatalf("expected 'too many levels of symbolic links' error, got %q", resp.Error)
+	}
+
+	// The target itself is a symlink loop: the open fails on the final
+	// component and must report the requested path.
+	resp = sess.handleRequest(Request{Cmd: "get", Path: "loop/loop"})
+	if resp.OK || resp.Error == "" {
+		t.Fatalf("expected symlink loop error, got %+v", resp)
+	}
+	if !strings.Contains(resp.Error, loopPath) {
+		t.Fatalf("expected error to include path %s, got %q", loopPath, resp.Error)
+	}
+	if !strings.Contains(resp.Error, "symbolic links") {
+		t.Fatalf("expected 'too many levels of symbolic links' error, got %q", resp.Error)
+	}
+}
+
+// TestServerHandleRequest_putToDirectoryIncludesPath verifies that a put
+// targeting an existing directory reports the path in its error.
+func TestServerHandleRequest_putToDirectoryIncludesPath(t *testing.T) {
+	tmp := t.TempDir()
+	d := filepath.Join(tmp, "adir")
+	if err := os.Mkdir(d, 0755); err != nil {
+		t.Fatalf("mkdir failed: %v", err)
+	}
+
+	sess := &ServerSession{currentDir: tmp}
+	resp := sess.handleRequest(Request{Cmd: "put", Path: "adir", Data: []byte("x")})
+	if resp.OK || resp.Error == "" {
+		t.Fatalf("expected put to directory to fail, got %+v", resp)
+	}
+	if !strings.Contains(resp.Error, d) {
+		t.Fatalf("expected error to include path %s, got %q", d, resp.Error)
+	}
+	if !strings.Contains(resp.Error, "is a directory") {
+		t.Fatalf("expected 'is a directory' error, got %q", resp.Error)
+	}
+}
+
+// TestServerHandleRequest_missingFileIncludesPath verifies that a missing
+// file is reported with its path for the commands that resolve it.
+func TestServerHandleRequest_missingFileIncludesPath(t *testing.T) {
+	tmp := t.TempDir()
+	missing := filepath.Join(tmp, "missing.txt")
+	sess := &ServerSession{currentDir: tmp}
+
+	for _, cmd := range []string{"stat", "get", "rm", "ls", "cd"} {
+		resp := sess.handleRequest(Request{Cmd: cmd, Path: "missing.txt"})
+		if resp.OK || resp.Error == "" {
+			t.Fatalf("expected error for %s of missing file, got %+v", cmd, resp)
+		}
+		if !strings.Contains(resp.Error, missing) {
+			t.Fatalf("%s: expected error to include path %s, got %q", cmd, missing, resp.Error)
+		}
 	}
 }
 


### PR DESCRIPTION
The sftp server reported raw syscall errors such as 'too many levels of symbolic links' (ELOOP), 'no such file or directory' and 'permission denied' without identifying the filepath that caused them. Wrap every syscall error in handleRequest and its helpers (open, stat, readdir, mkdirat, unlinkat, and the ancestor-execute traversal) with the path it concerns via a pathErr helper, following the os package's '<path>: <error>' convention. checkAncestorExecute now names the exact ancestor whose traversal failed.

On the client, propagate non-OK server responses through a serverError helper that prefixes the path known to the client when the server message does not already carry one (avoiding duplication), and add the path to the 'cannot upload/download a directory' errors.

Tests: symlink-loop errors include the failing path (ancestor and direct-open), put-to-directory and missing-file errors include the path, and client errors are enriched with the remote path without duplicating server-supplied paths.