### PR TITLE
sftp: follow symlinks on the client by default, add -no-follow-symlinks

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,13 @@ To use sftp mode on the client, run this to drop into a SFTP shell:
 
 Type `help` in the `sftp>` prompt to see what commands are available.
 
+Symbolic links are followed by default, both directions: `get` resolves
+server-side links (the server reports each link, the client follows it) and
+`put` resolves client-side links, including inside recursive transfers. Pass
+`-no-follow-symlinks` to disable this on the client: `get` then refuses to
+download a server-side symlink and `put` refuses to upload a client-side
+symlink.
+
 For non-interactive, scp-style copy, use `-scp`. Since `:` is already used for the port designation in the connection URL, the remote path is separated from the sshoq server URL with `%`. Add `-r` to copy directories recursively:
 
 Upload a local file to a remote path:

--- a/cmd/sshoq.go
+++ b/cmd/sshoq.go
@@ -629,6 +629,7 @@ func ClientMain() int {
 	flag.Var(&reverseTCP, "R", "alias for -reverse-tcp (may be specified multiple times)")
 	proxyJump := flag.String("proxy-jump", "", "if set, performs a proxy jump using the specified remote host as proxy (requires server with version >= 0.1.5)")
 	sftpMode := flag.Bool("sftp", false, "if set, start an interactive SFTP session")
+	noFollowSymlinks := flag.Bool("no-follow-symlinks", false, "if set with -sftp, do not follow symbolic links on the client (put source and get source, resolved client-side)")
 	scpMode := flag.Bool("scp", false, "if set, copy files to or from the remote host non-interactively, like scp")
 	scpRecursive := flag.Bool("r", false, "if set with -scp, recursively copy directories")
 
@@ -954,7 +955,7 @@ func ClientMain() int {
 	}
 
 	if *sftpMode {
-		err = sshoqsftp.RunInteractiveClient(c)
+		err = sshoqsftp.RunInteractiveClient(c, !*noFollowSymlinks)
 	} else if *scpMode {
 		err = sshoqsftp.RunScpClient(c, scpUpload, *scpRecursive, scpLocalPath, scpRemotePath)
 	} else {

--- a/sftp/cancel_test.go
+++ b/sftp/cancel_test.go
@@ -64,7 +64,7 @@ func TestUploadFileCancelled(t *testing.T) {
 		cancelAt:    1, // interrupt as soon as the first chunk is sent
 	}
 
-	err := uploadFile(ch, localPath, "remote.bin", cancel)
+	err := uploadFile(ch, localPath, "remote.bin", true, cancel)
 	if !errors.Is(err, ErrCancelled) {
 		t.Fatalf("expected ErrCancelled, got %v", err)
 	}
@@ -84,7 +84,7 @@ func TestUploadFileCancelledBeforeStart(t *testing.T) {
 	cancel.cancel()
 	ch := newMockChannel()
 
-	err := uploadFile(ch, localPath, "remote.bin", cancel)
+	err := uploadFile(ch, localPath, "remote.bin", true, cancel)
 	if !errors.Is(err, ErrCancelled) {
 		t.Fatalf("expected ErrCancelled, got %v", err)
 	}
@@ -111,7 +111,7 @@ func TestDownloadFileCancelled(t *testing.T) {
 		cancelAt: 2, // interrupt as soon as the first get request is sent
 	}
 
-	err := downloadFile(ch, "remote.bin", localPath, cancel)
+	err := downloadFile(ch, "remote.bin", localPath, true, cancel)
 	if !errors.Is(err, ErrCancelled) {
 		t.Fatalf("expected ErrCancelled, got %v", err)
 	}
@@ -127,7 +127,7 @@ func TestDownloadRecursiveCancelled(t *testing.T) {
 	cancel.cancel()
 	ch := newMockChannel()
 
-	err := downloadRecursive(ch, "remote-dir", filepath.Join(t.TempDir(), "out"), cancel)
+	err := downloadRecursive(ch, "remote-dir", filepath.Join(t.TempDir(), "out"), true, cancel)
 	if !errors.Is(err, ErrCancelled) {
 		t.Fatalf("expected ErrCancelled, got %v", err)
 	}
@@ -148,7 +148,7 @@ func TestUploadRecursiveCancelled(t *testing.T) {
 	cancel.cancel()
 	ch := newMockChannel()
 
-	err := uploadRecursive(ch, localDir, "remote-dir", cancel)
+	err := uploadRecursive(ch, localDir, "remote-dir", true, cancel)
 	if !errors.Is(err, ErrCancelled) {
 		t.Fatalf("expected ErrCancelled, got %v", err)
 	}

--- a/sftp/client.go
+++ b/sftp/client.go
@@ -19,7 +19,7 @@ import (
 	"github.com/h4sh5/sshoq/client"
 )
 
-func RunInteractiveClient(c *client.Client) error {
+func RunInteractiveClient(c *client.Client, follow bool) error {
 	channel, err := c.OpenChannel("sftp", 30000, 0)
 	if err != nil {
 		return fmt.Errorf("could not open sftp channel: %w", err)
@@ -157,7 +157,7 @@ func RunInteractiveClient(c *client.Client) error {
 		case "get":
 			cancel := &transferCancel{}
 			err := input.runTransfer(cancel, func() error {
-				return doGet(channel, localDir, remoteDir, parts, cancel)
+				return doGet(channel, localDir, remoteDir, parts, follow, cancel)
 			})
 			if err != nil {
 				if errors.Is(err, ErrCancelled) {
@@ -171,7 +171,7 @@ func RunInteractiveClient(c *client.Client) error {
 		case "put":
 			cancel := &transferCancel{}
 			err := input.runTransfer(cancel, func() error {
-				return doPut(channel, localDir, remoteDir, parts, cancel)
+				return doPut(channel, localDir, remoteDir, parts, follow, cancel)
 			})
 			if err != nil {
 				if errors.Is(err, ErrCancelled) {
@@ -550,7 +550,7 @@ func (r *interactiveReader) runTransfer(cancel *transferCancel, fn func() error)
 // un-globbed source is downloaded directly, preserving the previous behavior.
 // The -r flag is honored in both cases: directories (whether matched by the
 // pattern or named directly) are transferred recursively via downloadOne.
-func doGet(channel ssh3.Channel, localDir, remoteDir string, parts []string, cancel *transferCancel) error {
+func doGet(channel ssh3.Channel, localDir, remoteDir string, parts []string, follow bool, cancel *transferCancel) error {
 	recursive, remoteSource, localTarget, err := parseTransferArgs(parts, "get")
 	if err != nil {
 		return err
@@ -635,7 +635,7 @@ func doGet(channel ssh3.Channel, localDir, remoteDir string, parts []string, can
 				// A single match may target a file name directly.
 				localFile = destDir
 			}
-			if err := downloadOne(channel, remoteFile, localFile, recursive, cancel); err != nil {
+			if err := downloadOne(channel, remoteFile, localFile, recursive, follow, cancel); err != nil {
 				return err
 			}
 		}
@@ -662,18 +662,18 @@ func doGet(channel ssh3.Channel, localDir, remoteDir string, parts []string, can
 		}
 	}
 	localFile = resolveLocalPath(localDir, localFile)
-	return downloadOne(channel, remoteFile, localFile, recursive, cancel)
+	return downloadOne(channel, remoteFile, localFile, recursive, follow, cancel)
 }
 
 // downloadOne downloads remoteFile to localFile, descending into directories when
 // recursive is set. It reproduces the transfer behavior of a non-glob "get" and
 // is shared by the glob and non-glob paths of doGet so that wildcards work the
 // same way with and without -r.
-func downloadOne(channel ssh3.Channel, remoteFile, localFile string, recursive bool, cancel *transferCancel) error {
+func downloadOne(channel ssh3.Channel, remoteFile, localFile string, recursive, follow bool, cancel *transferCancel) error {
 	if recursive {
-		return downloadRecursive(channel, remoteFile, localFile, cancel)
+		return downloadRecursive(channel, remoteFile, localFile, follow, cancel)
 	}
-	return downloadFile(channel, remoteFile, localFile, cancel)
+	return downloadFile(channel, remoteFile, localFile, follow, cancel)
 }
 
 // doPut uploads a local file or directory, or every local file matching a
@@ -689,7 +689,7 @@ func downloadOne(channel ssh3.Channel, remoteFile, localFile string, recursive b
 // name or a directory, while multiple sources require an existing directory
 // (or no target, in which case each source is uploaded under its own
 // basename).
-func doPut(channel ssh3.Channel, localDir, remoteDir string, parts []string, cancel *transferCancel) error {
+func doPut(channel ssh3.Channel, localDir, remoteDir string, parts []string, follow bool, cancel *transferCancel) error {
 	recursive, localSource, remoteTarget, err := parseTransferArgs(parts, "put")
 	if err != nil {
 		return err
@@ -758,7 +758,7 @@ func doPut(channel ssh3.Channel, localDir, remoteDir string, parts []string, can
 			remoteFile = path.Join(remoteDir, remoteFile)
 		}
 
-		if err := uploadOne(channel, localFile, remoteFile, recursive, cancel); err != nil {
+		if err := uploadOne(channel, localFile, remoteFile, recursive, follow, cancel); err != nil {
 			return err
 		}
 	}
@@ -840,47 +840,64 @@ func parseTransferArgs(parts []string, cmd string) (recursive bool, source strin
 	return recursive, source, target, nil
 }
 
-func downloadRecursive(channel ssh3.Channel, remotePath, localPath string, cancel *transferCancel) error {
+func downloadRecursive(channel ssh3.Channel, remotePath, localPath string, follow bool, cancel *transferCancel) error {
 	if cancel.cancelled() {
 		return ErrCancelled
 	}
-	statResp, err := doRequest(channel, &Request{Cmd: "stat", Path: remotePath})
+
+	// Resolve any server-side symbolic links on the way to remotePath. When
+	// follow is false a trailing symlink is left unresolved so it can be
+	// rejected below; when follow is true the client follows each link hop by
+	// asking the server for its target.
+	resolved, info, err := resolveRemote(channel, remotePath, follow)
 	if err != nil {
 		return err
 	}
-	if !statResp.OK {
-		return serverError(remotePath, statResp.Error)
+	if !follow && info != nil && info.IsSymlink {
+		return fmt.Errorf("Cannot download %s: symbolic link", remotePath)
 	}
-	if statResp.Info != nil && statResp.Info.IsDir {
+
+	if info != nil && info.IsDir {
 		if err := os.MkdirAll(localPath, 0o755); err != nil {
 			return err
 		}
-		resp, err := doRequest(channel, &Request{Cmd: "ls", Path: remotePath})
+		resp, err := doRequest(channel, &Request{Cmd: "ls", Path: resolved})
 		if err != nil {
 			return err
 		}
 		if !resp.OK {
-			return serverError(remotePath, resp.Error)
+			return serverError(resolved, resp.Error)
 		}
 		for _, entry := range resp.Entries {
-			childRemote := path.Join(remotePath, entry.Name)
+			childRemote := path.Join(resolved, entry.Name)
 			childLocal := filepath.Join(localPath, entry.Name)
-			if entry.IsDir {
-				if err := downloadRecursive(channel, childRemote, childLocal, cancel); err != nil {
+			switch {
+			case entry.IsDir:
+				if err := downloadRecursive(channel, childRemote, childLocal, follow, cancel); err != nil {
 					return err
 				}
-			} else if err := downloadFileContents(channel, childRemote, childLocal, entry.Size, cancel); err != nil {
-				return err
+			case entry.IsSymlink && !follow:
+				return fmt.Errorf("Cannot download %s: symbolic link", childRemote)
+			case entry.IsSymlink:
+				// Recurse so the symlink is resolved (and followed if it points
+				// to a directory, downloaded if it points to a file).
+				if err := downloadRecursive(channel, childRemote, childLocal, follow, cancel); err != nil {
+					return err
+				}
+			default:
+				if err := downloadFileContents(channel, childRemote, childLocal, entry.Size, cancel); err != nil {
+					return err
+				}
 			}
 		}
 		return nil
 	}
 
 	var total int64
-	if statResp.Info != nil {
-		total = statResp.Info.Size
+	if info != nil {
+		total = info.Size
 	}
-	return downloadFileContents(channel, remotePath, localPath, total, cancel)
+	return downloadFileContents(channel, resolved, localPath, total, cancel)
 }
 
 // downloadFileContents downloads remotePath into localPath, displaying a
@@ -996,23 +1013,37 @@ func downloadFileContents(channel ssh3.Channel, remotePath, localPath string, to
 // uploadOne uploads localFile to remoteFile, descending into directories when
 // recursive is set. It is the upload counterpart of downloadOne and is shared
 // by the glob and non-glob paths of doPut.
-func uploadOne(channel ssh3.Channel, localFile, remoteFile string, recursive bool, cancel *transferCancel) error {
+func uploadOne(channel ssh3.Channel, localFile, remoteFile string, recursive, follow bool, cancel *transferCancel) error {
 	if recursive {
-		return uploadRecursive(channel, localFile, remoteFile, cancel)
+		return uploadRecursive(channel, localFile, remoteFile, follow, cancel)
 	}
-	return uploadFile(channel, localFile, remoteFile, cancel)
+	return uploadFile(channel, localFile, remoteFile, follow, cancel)
 }
 
-func uploadRecursive(channel ssh3.Channel, localPath, remotePath string, cancel *transferCancel) error {
+// statLocal reports the local FileInfo used to decide whether a path is a
+// directory during an upload. With follow it uses stat (resolving symlinks, so
+// a symlink to a directory is uploaded recursively); with follow=false it uses
+// lstat so a symlink is seen as a symlink rather than its target.
+func statLocal(p string, follow bool) (os.FileInfo, error) {
+	if follow {
+		return os.Stat(p)
+	}
+	return os.Lstat(p)
+}
+
+func uploadRecursive(channel ssh3.Channel, localPath, remotePath string, follow bool, cancel *transferCancel) error {
 	if cancel.cancelled() {
 		return ErrCancelled
 	}
-	info, err := os.Stat(localPath)
+	info, err := statLocal(localPath, follow)
 	if err != nil {
 		return err
 	}
+	if !follow && info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("Cannot upload %s: symbolic link", localPath)
+	}
 	if !info.IsDir() {
-		return uploadFile(channel, localPath, remotePath, cancel)
+		return uploadFile(channel, localPath, remotePath, follow, cancel)
 	}
 	if err := ensureRemoteDir(channel, remotePath); err != nil {
 		return err
@@ -1025,15 +1056,18 @@ func uploadRecursive(channel ssh3.Channel, localPath, remotePath string, cancel 
 	for _, entry := range entries {
 		childLocal := filepath.Join(localPath, entry.Name())
 		childRemote := path.Join(remotePath, entry.Name())
-		childInfo, err := entry.Info()
+		childInfo, err := statLocal(childLocal, follow)
 		if err != nil {
 			return err
 		}
+		if !follow && childInfo.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("Cannot upload %s: symbolic link", childLocal)
+		}
 		if childInfo.IsDir() {
-			if err := uploadRecursive(channel, childLocal, childRemote, cancel); err != nil {
+			if err := uploadRecursive(channel, childLocal, childRemote, follow, cancel); err != nil {
 				return err
 			}
-		} else if err := uploadFile(channel, childLocal, childRemote, cancel); err != nil {
+		} else if err := uploadFile(channel, childLocal, childRemote, follow, cancel); err != nil {
 			return err
 		}
 	}
@@ -1090,6 +1124,12 @@ func printHelp() {
   exit/quit       exit
 
 Ctrl+C during a get/put cancels the transfer and returns to the prompt.
+
+Symbolic links are followed by default: get resolves server-side links (the
+server reports each link, the client follows it) and put resolves client-side
+links, including inside recursive transfers. Start sshoq with
+-no-follow-symlinks to disable this on the client: get then refuses to download
+a server-side symlink and put refuses to upload a client-side symlink.
 
 Paths are parsed like OpenSSH sftp: single quotes ('...') and double quotes
 ("...") protect spaces and metacharacters, and a backslash escapes the next
@@ -1201,26 +1241,79 @@ func serverError(path, msg string) error {
 	return fmt.Errorf("%s: %s", path, msg)
 }
 
-func downloadFile(channel ssh3.Channel, remotePath, localPath string, cancel *transferCancel) error {
-	statResp, err := doRequest(channel, &Request{Cmd: "stat", Path: remotePath})
+// downloadFile downloads remoteFile to localFile, resolving any server-side
+// symbolic links by asking the server for each link's target (see resolveRemote)
+// unless follow is false, in which case a trailing symlink is rejected rather
+// than followed.
+func downloadFile(channel ssh3.Channel, remotePath, localPath string, follow bool, cancel *transferCancel) error {
+	resolved, info, err := resolveRemote(channel, remotePath, follow)
 	if err != nil {
 		return err
 	}
-	if !statResp.OK {
-		return serverError(remotePath, statResp.Error)
+	if !follow && info != nil && info.IsSymlink {
+		return fmt.Errorf("Cannot download %s: symbolic link", remotePath)
 	}
-	if statResp.Info != nil && statResp.Info.IsDir {
+	if info != nil && info.IsDir {
 		return fmt.Errorf("cannot download a directory: %s", remotePath)
 	}
 
 	var total int64
-	if statResp.Info != nil {
-		total = statResp.Info.Size
+	if info != nil {
+		total = info.Size
 	}
-	return downloadFileContents(channel, remotePath, localPath, total, cancel)
+	return downloadFileContents(channel, resolved, localPath, total, cancel)
 }
 
-func uploadFile(channel ssh3.Channel, localPath, remotePath string, cancel *transferCancel) error {
+// maxSymlinkFollow caps how many server-side symbolic links the client will
+// follow while resolving a remote path, mirroring the kernel's ELOOP limit of
+// 40 so a symlink loop is reported instead of looping forever.
+const maxSymlinkFollow = 40
+
+// resolveRemote follows symbolic links on the remote side one hop at a time,
+// asking the server to stat the current path and, when it is a symlink, using
+// the link target it returns as the next path. It returns the final resolved
+// path and its FileInfo. When follow is false a trailing symlink is returned
+// unresolved (with is-symlink set) so the caller can decide what to do.
+// Symlink following is client-side: the server merely reports each next link
+// to follow, so a client-side -no-follow switch can disable it.
+func resolveRemote(channel ssh3.Channel, p string, follow bool) (string, *FileInfo, error) {
+	cur := p
+	for i := 0; i < maxSymlinkFollow; i++ {
+		resp, err := doRequest(channel, &Request{Cmd: "stat", Path: cur})
+		if err != nil {
+			return "", nil, err
+		}
+		if !resp.OK {
+			return "", nil, serverError(cur, resp.Error)
+		}
+		info := resp.Info
+		if info == nil || !follow || !info.IsSymlink {
+			return cur, info, nil
+		}
+		if info.LinkTarget == "" {
+			return "", nil, fmt.Errorf("%s: empty symbolic link target", cur)
+		}
+		// Resolve the target against the symlink's own directory, mirroring
+		// how the kernel resolves a relative link target.
+		if path.IsAbs(info.LinkTarget) {
+			cur = path.Clean(info.LinkTarget)
+		} else {
+			cur = path.Clean(path.Join(path.Dir(cur), info.LinkTarget))
+		}
+	}
+	return "", nil, fmt.Errorf("%s: too many levels of symbolic links", p)
+}
+
+func uploadFile(channel ssh3.Channel, localPath, remotePath string, follow bool, cancel *transferCancel) error {
+	// By default a client-side symbolic link is followed (its target is
+	// uploaded); with follow=false a symlink is rejected rather than followed,
+	// matching OpenSSH's put -P.
+	if !follow {
+		if fi, err := os.Lstat(localPath); err == nil && fi.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("Cannot upload %s: symbolic link", localPath)
+		}
+	}
+
 	f, err := os.Open(localPath)
 	if err != nil {
 		return err

--- a/sftp/protocol.go
+++ b/sftp/protocol.go
@@ -29,15 +29,17 @@ type Request struct {
 }
 
 type FileInfo struct {
-	Name      string `json:"name"`
-	Size      int64  `json:"size"`
-	Mode      uint32 `json:"mode"`
-	IsDir     bool   `json:"is_dir"`
-	ModTime   int64  `json:"mod_time"`
-	UID       uint32 `json:"uid"`
-	GID       uint32 `json:"gid"`
-	UserName  string `json:"user_name,omitempty"`
-	GroupName string `json:"group_name,omitempty"`
+	Name       string `json:"name"`
+	Size       int64  `json:"size"`
+	Mode       uint32 `json:"mode"`
+	IsDir      bool   `json:"is_dir"`
+	IsSymlink  bool   `json:"is_symlink,omitempty"`
+	LinkTarget string `json:"link_target,omitempty"`
+	ModTime    int64  `json:"mod_time"`
+	UID        uint32 `json:"uid"`
+	GID        uint32 `json:"gid"`
+	UserName   string `json:"user_name,omitempty"`
+	GroupName  string `json:"group_name,omitempty"`
 }
 
 type Response struct {

--- a/sftp/quoting_test.go
+++ b/sftp/quoting_test.go
@@ -575,7 +575,7 @@ func TestClientDoGetQuotedPath(t *testing.T) {
 		makeJSONDataMsg(&Response{OK: true, Data: []byte{}}),
 	)
 	// parts simulate the output of makeargv("get 'Downloads/Test File.txt'").
-	if err := doGet(ch, localDir, "/remote", []string{"get", "Downloads/Test File.txt"}, nil); err != nil {
+	if err := doGet(ch, localDir, "/remote", []string{"get", "Downloads/Test File.txt"}, true, nil); err != nil {
 		t.Fatalf("doGet error: %v", err)
 	}
 	var got Request
@@ -609,7 +609,7 @@ func TestClientDoGetEscapedGlobMetachar(t *testing.T) {
 		makeJSONDataMsg(&Response{OK: true, Data: []byte{}}),
 	)
 	// parts simulate the output of makeargv("get 'foo*.txt'").
-	if err := doGet(ch, localDir, "/remote", []string{"get", `foo\*.txt`}, nil); err != nil {
+	if err := doGet(ch, localDir, "/remote", []string{"get", `foo\*.txt`}, true, nil); err != nil {
 		t.Fatalf("doGet error: %v", err)
 	}
 	var got Request

--- a/sftp/scp.go
+++ b/sftp/scp.go
@@ -61,9 +61,9 @@ func scpUpload(channel ssh3.Channel, recursive bool, localPath, remotePath strin
 	}
 
 	if recursive {
-		return uploadRecursive(channel, localPath, remotePath, cancel)
+		return uploadRecursive(channel, localPath, remotePath, true, cancel)
 	}
-	return uploadFile(channel, localPath, remotePath, cancel)
+	return uploadFile(channel, localPath, remotePath, true, cancel)
 }
 
 // scpDownload copies a remote file or directory to the local machine.
@@ -79,9 +79,9 @@ func scpDownload(channel ssh3.Channel, recursive bool, remotePath, localPath str
 	}
 
 	if recursive {
-		return downloadRecursive(channel, remotePath, localPath, cancel)
+		return downloadRecursive(channel, remotePath, localPath, true, cancel)
 	}
-	return downloadFile(channel, remotePath, localPath, cancel)
+	return downloadFile(channel, remotePath, localPath, true, cancel)
 }
 
 // isRemoteDir reports whether the remote path refers to an existing

--- a/sftp/server.go
+++ b/sftp/server.go
@@ -249,7 +249,10 @@ func (s *ServerSession) handleRequest(req Request) *Response {
 			break
 		}
 		dirfd, pathArg := s.dirFDAndPath(req.Path, target)
-		fd, err := unix.Openat(dirfd, pathArg, unix.O_RDONLY|unix.O_DIRECTORY|unix.O_NOFOLLOW|unix.O_CLOEXEC, 0)
+		// Change into the directory, following symbolic links by default. The
+		// path's final component is resolved to whatever it points at; ancestor
+		// components are resolved by the kernel as the path is traversed.
+		fd, err := unix.Openat(dirfd, pathArg, unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC, 0)
 		if err != nil {
 			resp.Error = pathErr(target, err).Error()
 			break
@@ -273,7 +276,11 @@ func (s *ServerSession) handleRequest(req Request) *Response {
 			break
 		}
 		dirfd, pathArg := s.dirFDAndPath(req.Path, target)
-		fd, err := unix.Openat(dirfd, pathArg, unix.O_RDONLY|unix.O_DIRECTORY|unix.O_NOFOLLOW|unix.O_CLOEXEC, 0)
+		// List a directory, following symbolic links by default so that
+		// "ls symlink-to-dir" lists the target directory's entries (matching
+		// OpenSSH sftp). Individual entries are still reported via lstat, so
+		// symlinks appear as symlinks with their target.
+		fd, err := unix.Openat(dirfd, pathArg, unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC, 0)
 		if err != nil {
 			resp.Error = pathErr(target, err).Error()
 			break
@@ -304,7 +311,7 @@ func (s *ServerSession) handleRequest(req Request) *Response {
 				continue
 			}
 			uid, gid := ownershipFromInfo(info)
-			resp.Entries = append(resp.Entries, FileInfo{
+			ti := FileInfo{
 				Name:      e.Name(),
 				Size:      info.Size(),
 				Mode:      uint32(info.Mode()),
@@ -314,7 +321,16 @@ func (s *ServerSession) handleRequest(req Request) *Response {
 				GID:       gid,
 				UserName:  s.userName(uid),
 				GroupName: s.groupName(gid),
-			})
+			}
+			// Report symbolic links so the client can follow the next hop. e.Info
+			// is an lstat, so a symlink is reported as a symlink (never resolved).
+			if info.Mode()&os.ModeSymlink != 0 {
+				ti.IsSymlink = true
+				if lt, err := os.Readlink(filepath.Join(target, e.Name())); err == nil {
+					ti.LinkTarget = lt
+				}
+			}
+			resp.Entries = append(resp.Entries, ti)
 		}
 
 	case "stat":
@@ -324,7 +340,7 @@ func (s *ServerSession) handleRequest(req Request) *Response {
 			break
 		}
 		resp.OK = true
-		resp.Info = &FileInfo{
+		ti := &FileInfo{
 			Name:      filepath.Base(target),
 			Size:      st.Size,
 			Mode:      uint32(st.Mode),
@@ -335,6 +351,15 @@ func (s *ServerSession) handleRequest(req Request) *Response {
 			UserName:  s.userName(st.Uid),
 			GroupName: s.groupName(st.Gid),
 		}
+		// statPath uses lstat, so a symlink is reported as a symlink with its
+		// target (the "next link to follow"), leaving resolution to the client.
+		if (st.Mode & unix.S_IFMT) == unix.S_IFLNK {
+			ti.IsSymlink = true
+			if lt, err := os.Readlink(target); err == nil {
+				ti.LinkTarget = lt
+			}
+		}
+		resp.Info = ti
 
 	case "get":
 		if err := s.checkAncestorExecute(target); err != nil {

--- a/sftp/sftp_test.go
+++ b/sftp/sftp_test.go
@@ -670,7 +670,7 @@ func TestDownloadFile(t *testing.T) {
 		makeJSONDataMsg(done),
 	)
 
-	if err := downloadFile(ch, "remote.txt", localPath, nil); err != nil {
+	if err := downloadFile(ch, "remote.txt", localPath, true, nil); err != nil {
 		t.Fatalf("downloadFile error: %v", err)
 	}
 	got, err := os.ReadFile(localPath)
@@ -684,7 +684,7 @@ func TestDownloadFile(t *testing.T) {
 
 func TestDownloadFile_StatFail(t *testing.T) {
 	ch := newMockChannel(makeJSONDataMsg(&Response{ID: 1, OK: false, Error: "no such file"}))
-	err := downloadFile(ch, "missing", filepath.Join(t.TempDir(), "out"), nil)
+	err := downloadFile(ch, "missing", filepath.Join(t.TempDir(), "out"), true, nil)
 	if err == nil {
 		t.Fatal("expected error for stat failure")
 	}
@@ -695,7 +695,7 @@ func TestDownloadFile_StatFail(t *testing.T) {
 // errors like "too many levels of symbolic links" identify the file.
 func TestDownloadFile_ServerErrorIncludesPath(t *testing.T) {
 	ch := newMockChannel(makeJSONDataMsg(&Response{ID: 1, OK: false, Error: "too many levels of symbolic links"}))
-	err := downloadFile(ch, "loop/file.txt", filepath.Join(t.TempDir(), "out"), nil)
+	err := downloadFile(ch, "loop/file.txt", filepath.Join(t.TempDir(), "out"), true, nil)
 	if err == nil {
 		t.Fatal("expected error from server")
 	}
@@ -709,7 +709,7 @@ func TestDownloadFile_ServerErrorIncludesPath(t *testing.T) {
 func TestDownloadFile_ServerErrorWithPathNotDuplicated(t *testing.T) {
 	const serverErr = "/remote/loop/file.txt: too many levels of symbolic links"
 	ch := newMockChannel(makeJSONDataMsg(&Response{ID: 1, OK: false, Error: serverErr}))
-	err := downloadFile(ch, "/remote/loop/file.txt", filepath.Join(t.TempDir(), "out"), nil)
+	err := downloadFile(ch, "/remote/loop/file.txt", filepath.Join(t.TempDir(), "out"), true, nil)
 	if err == nil || err.Error() != serverErr {
 		t.Fatalf("expected unchanged server error, got: %v", err)
 	}
@@ -723,7 +723,7 @@ func TestUploadFile_ServerErrorIncludesPath(t *testing.T) {
 	os.WriteFile(localPath, []byte("x"), 0644)
 
 	ch := newMockChannel(makeJSONDataMsg(&Response{ID: 1, OK: false, Error: "too many levels of symbolic links"}))
-	err := uploadFile(ch, localPath, "loop/out.txt", nil)
+	err := uploadFile(ch, localPath, "loop/out.txt", true, nil)
 	if err == nil {
 		t.Fatal("expected error from server")
 	}
@@ -744,7 +744,7 @@ func TestUploadFile(t *testing.T) {
 
 	// Verify that uploadFile sends the data through the channel without error.
 	// The remote side would write the file; our mock just acknowledges.
-	if err := uploadFile(ch, localPath, "remote.txt", nil); err != nil {
+	if err := uploadFile(ch, localPath, "remote.txt", true, nil); err != nil {
 		t.Fatalf("uploadFile error: %v", err)
 	}
 	// One chunk was sent because the content is smaller than ChunkSize.
@@ -768,7 +768,7 @@ func TestDownloadRecursive(t *testing.T) {
 		makeJSONDataMsg(&Response{ID: 8, OK: true, Data: []byte{}}),
 	)
 
-	if err := downloadRecursive(ch, "remote-dir", localRoot, nil); err != nil {
+	if err := downloadRecursive(ch, "remote-dir", localRoot, true, nil); err != nil {
 		t.Fatalf("downloadRecursive error: %v", err)
 	}
 
@@ -804,7 +804,7 @@ func TestUploadRecursive(t *testing.T) {
 		makeJSONDataMsg(&Response{ID: 5, OK: true}),
 	)
 
-	if err := uploadRecursive(ch, localRoot, "remote-dir", nil); err != nil {
+	if err := uploadRecursive(ch, localRoot, "remote-dir", true, nil); err != nil {
 		t.Fatalf("uploadRecursive error: %v", err)
 	}
 	if len(ch.Writes) != 5 {
@@ -818,7 +818,7 @@ func TestUploadFile_DirectoryError(t *testing.T) {
 	os.Mkdir(dirPath, 0755)
 
 	ch := newMockChannel()
-	err := uploadFile(ch, dirPath, "/remote/file", nil)
+	err := uploadFile(ch, dirPath, "/remote/file", true, nil)
 	if err == nil || !strings.Contains(err.Error(), "cannot upload a directory") {
 		t.Fatalf("expected directory upload error, got: %v", err)
 	}
@@ -944,7 +944,7 @@ func TestUploadFilePipelined(t *testing.T) {
 	ch := newWindowedMockChannel(n, msgs...)
 
 	if err := runWithTimeout(t, "pipelined upload", func() error {
-		return uploadFile(ch, localPath, "remote.bin", nil)
+		return uploadFile(ch, localPath, "remote.bin", true, nil)
 	}); err != nil {
 		t.Fatalf("uploadFile error: %v", err)
 	}
@@ -1773,7 +1773,7 @@ func TestClientDoGetNoGlob(t *testing.T) {
 		makeJSONDataMsg(&Response{OK: true, Data: []byte{}}),
 	)
 
-	if err := doGet(ch, localDir, "/remote", []string{"get", "remote.txt"}, nil); err != nil {
+	if err := doGet(ch, localDir, "/remote", []string{"get", "remote.txt"}, true, nil); err != nil {
 		t.Fatalf("doGet error: %v", err)
 	}
 
@@ -1809,7 +1809,7 @@ func TestClientDoGetWildcard(t *testing.T) {
 		makeJSONDataMsg(&Response{OK: true, Data: []byte{}}),
 	)
 
-	if err := doGet(ch, localDir, "/remote/path", []string{"get", "test*"}, nil); err != nil {
+	if err := doGet(ch, localDir, "/remote/path", []string{"get", "test*"}, true, nil); err != nil {
 		t.Fatalf("doGet error: %v", err)
 	}
 
@@ -1848,7 +1848,7 @@ func TestClientDoGetNoMatch(t *testing.T) {
 		Entries: lsEntries("one", "two"),
 	}))
 
-	if err := doGet(ch, localDir, "/remote", []string{"get", "zzz*"}, nil); err != nil {
+	if err := doGet(ch, localDir, "/remote", []string{"get", "zzz*"}, true, nil); err != nil {
 		t.Fatalf("doGet error: %v", err)
 	}
 	if len(ch.Writes) != 1 {
@@ -1865,7 +1865,7 @@ func TestClientDoGetNoMatch(t *testing.T) {
 
 func TestClientDoGetInvalidPattern(t *testing.T) {
 	ch := newMockChannel(makeJSONDataMsg(&Response{OK: true, Entries: lsEntries("a")}))
-	err := doGet(ch, t.TempDir(), "/remote", []string{"get", "["}, nil)
+	err := doGet(ch, t.TempDir(), "/remote", []string{"get", "["}, true, nil)
 	if err == nil {
 		t.Fatal("expected error for invalid glob pattern")
 	}
@@ -1881,7 +1881,7 @@ func TestClientDoGetRecursiveDir(t *testing.T) {
 		makeJSONDataMsg(&Response{OK: true, Data: []byte{}}),
 	)
 
-	if err := doGet(ch, localDir, "/remote", []string{"get", "-r", "d"}, nil); err != nil {
+	if err := doGet(ch, localDir, "/remote", []string{"get", "-r", "d"}, true, nil); err != nil {
 		t.Fatalf("doGet -r dir error: %v", err)
 	}
 
@@ -1920,7 +1920,7 @@ func TestClientDoGetRecursiveWildcard(t *testing.T) {
 		makeJSONDataMsg(&Response{OK: true, Data: []byte{}}),
 	)
 
-	if err := doGet(ch, localDir, "/remote/path", []string{"get", "-r", "test*"}, nil); err != nil {
+	if err := doGet(ch, localDir, "/remote/path", []string{"get", "-r", "test*"}, true, nil); err != nil {
 		t.Fatalf("doGet -r wildcard error: %v", err)
 	}
 
@@ -1967,7 +1967,7 @@ func TestClientDoGetRecursiveWildcardNoMatch(t *testing.T) {
 		Entries: lsEntries("one", "two"),
 	}))
 
-	if err := doGet(ch, localDir, "/remote", []string{"get", "-r", "zzz*"}, nil); err != nil {
+	if err := doGet(ch, localDir, "/remote", []string{"get", "-r", "zzz*"}, true, nil); err != nil {
 		t.Fatalf("doGet error: %v", err)
 	}
 	if len(ch.Writes) != 1 {
@@ -1993,7 +1993,7 @@ func TestClientDoPutWildcard(t *testing.T) {
 		makeJSONDataMsg(&Response{ID: 2, OK: true}), // put b.txt
 	)
 
-	if err := doPut(ch, localDir, "/remote", []string{"put", "*.txt"}, nil); err != nil {
+	if err := doPut(ch, localDir, "/remote", []string{"put", "*.txt"}, true, nil); err != nil {
 		t.Fatalf("doPut error: %v", err)
 	}
 
@@ -2027,7 +2027,7 @@ func TestClientDoPutWildcardSubdirPattern(t *testing.T) {
 
 	ch := newMockChannel(makeJSONDataMsg(&Response{ID: 1, OK: true}))
 
-	if err := doPut(ch, localDir, "/remote", []string{"put", "sub/*.txt"}, nil); err != nil {
+	if err := doPut(ch, localDir, "/remote", []string{"put", "sub/*.txt"}, true, nil); err != nil {
 		t.Fatalf("doPut error: %v", err)
 	}
 	if len(ch.Writes) != 1 {
@@ -2056,7 +2056,7 @@ func TestClientDoPutWildcardToRemoteDir(t *testing.T) {
 		makeJSONDataMsg(&Response{ID: 3, OK: true}),                                             // put b.log
 	)
 
-	if err := doPut(ch, localDir, "/remote", []string{"put", "*.log", "logs"}, nil); err != nil {
+	if err := doPut(ch, localDir, "/remote", []string{"put", "*.log", "logs"}, true, nil); err != nil {
 		t.Fatalf("doPut error: %v", err)
 	}
 
@@ -2087,7 +2087,7 @@ func TestClientDoPutWildcardToNonDirectory(t *testing.T) {
 
 	ch := newMockChannel(makeJSONDataMsg(&Response{ID: 1, OK: false, Error: "no such file"}))
 
-	err := doPut(ch, localDir, "/remote", []string{"put", "*.log", "logs"}, nil)
+	err := doPut(ch, localDir, "/remote", []string{"put", "*.log", "logs"}, true, nil)
 	if err == nil {
 		t.Fatal("expected error for multi-match put to non-directory")
 	}
@@ -2107,7 +2107,7 @@ func TestClientDoPutSingleToRemoteDir(t *testing.T) {
 		makeJSONDataMsg(&Response{ID: 2, OK: true}),
 	)
 
-	if err := doPut(ch, localDir, "/remote", []string{"put", "a.txt", "dir"}, nil); err != nil {
+	if err := doPut(ch, localDir, "/remote", []string{"put", "a.txt", "dir"}, true, nil); err != nil {
 		t.Fatalf("doPut error: %v", err)
 	}
 	if len(ch.Writes) != 2 {
@@ -2134,7 +2134,7 @@ func TestClientDoPutSingleToNewName(t *testing.T) {
 		makeJSONDataMsg(&Response{ID: 2, OK: true}),
 	)
 
-	if err := doPut(ch, localDir, "/remote", []string{"put", "a.txt", "newname"}, nil); err != nil {
+	if err := doPut(ch, localDir, "/remote", []string{"put", "a.txt", "newname"}, true, nil); err != nil {
 		t.Fatalf("doPut error: %v", err)
 	}
 	if len(ch.Writes) != 2 {
@@ -2159,7 +2159,7 @@ func TestClientDoPutEscapedGlob(t *testing.T) {
 	ch := newMockChannel(makeJSONDataMsg(&Response{ID: 1, OK: true}))
 
 	// parts[1] is what makeargv produces for the typed `star\*file`.
-	if err := doPut(ch, localDir, "/remote", []string{"put", `star\*file`}, nil); err != nil {
+	if err := doPut(ch, localDir, "/remote", []string{"put", `star\*file`}, true, nil); err != nil {
 		t.Fatalf("doPut error: %v", err)
 	}
 	if len(ch.Writes) != 1 {
@@ -2194,7 +2194,7 @@ func TestClientDoPutQuotedMetachar(t *testing.T) {
 	}
 
 	ch := newMockChannel(makeJSONDataMsg(&Response{OK: true}))
-	if err := doPut(ch, localDir, "/remote", parts, nil); err != nil {
+	if err := doPut(ch, localDir, "/remote", parts, true, nil); err != nil {
 		t.Fatalf("doPut error: %v", err)
 	}
 
@@ -2216,7 +2216,7 @@ func TestClientDoPutNoMatch(t *testing.T) {
 	localDir := t.TempDir()
 
 	ch := newMockChannel()
-	err := doPut(ch, localDir, "/remote", []string{"put", "zzz*.txt"}, nil)
+	err := doPut(ch, localDir, "/remote", []string{"put", "zzz*.txt"}, true, nil)
 	if err == nil {
 		t.Fatal("expected error for non-matching put source")
 	}
@@ -2231,7 +2231,7 @@ func TestClientDoPutInvalidPattern(t *testing.T) {
 	localDir := t.TempDir()
 
 	ch := newMockChannel()
-	err := doPut(ch, localDir, "/remote", []string{"put", "["}, nil)
+	err := doPut(ch, localDir, "/remote", []string{"put", "["}, true, nil)
 	if err == nil {
 		t.Fatal("expected error for invalid glob pattern")
 	}
@@ -2254,7 +2254,7 @@ func TestClientDoPutRecursiveWildcard(t *testing.T) {
 		makeJSONDataMsg(&Response{ID: 5, OK: true}),                                               // put /remote/solo.txt
 	)
 
-	if err := doPut(ch, localDir, "/remote", []string{"put", "-r", "*"}, nil); err != nil {
+	if err := doPut(ch, localDir, "/remote", []string{"put", "-r", "*"}, true, nil); err != nil {
 		t.Fatalf("doPut -r error: %v", err)
 	}
 	if len(ch.Writes) != 5 {
@@ -2293,7 +2293,7 @@ func TestClientDoGetWildcardToLocalDir(t *testing.T) {
 		makeJSONDataMsg(&Response{OK: true, Data: []byte{}}),
 	)
 
-	if err := doGet(ch, localDir, "/remote/path", []string{"get", "test*", "dest"}, nil); err != nil {
+	if err := doGet(ch, localDir, "/remote/path", []string{"get", "test*", "dest"}, true, nil); err != nil {
 		t.Fatalf("doGet error: %v", err)
 	}
 
@@ -2335,7 +2335,7 @@ func TestClientDoGetWildcardToTrailingSlashDir(t *testing.T) {
 		makeJSONDataMsg(&Response{OK: true, Data: []byte{}}),
 	)
 
-	if err := doGet(ch, localDir, "/remote/path", []string{"get", "test*", "newdir/"}, nil); err != nil {
+	if err := doGet(ch, localDir, "/remote/path", []string{"get", "test*", "newdir/"}, true, nil); err != nil {
 		t.Fatalf("doGet error: %v", err)
 	}
 
@@ -2361,7 +2361,7 @@ func TestClientDoGetWildcardSingleToFile(t *testing.T) {
 		makeJSONDataMsg(&Response{OK: true, Data: []byte{}}),
 	)
 
-	if err := doGet(ch, localDir, "/remote/path", []string{"get", "test*", "out.txt"}, nil); err != nil {
+	if err := doGet(ch, localDir, "/remote/path", []string{"get", "test*", "out.txt"}, true, nil); err != nil {
 		t.Fatalf("doGet error: %v", err)
 	}
 
@@ -2382,7 +2382,7 @@ func TestClientDoGetWildcardMultiToNonDir(t *testing.T) {
 
 	ch := newMockChannel(makeJSONDataMsg(&Response{OK: true, Entries: lsEntries("test", "testa")}))
 
-	err := doGet(ch, localDir, "/remote/path", []string{"get", "test*", "out.txt"}, nil)
+	err := doGet(ch, localDir, "/remote/path", []string{"get", "test*", "out.txt"}, true, nil)
 	if err == nil {
 		t.Fatal("expected error for multi-match get to non-directory")
 	}
@@ -2405,7 +2405,7 @@ func TestClientDoGetToExistingLocalDir(t *testing.T) {
 		makeJSONDataMsg(&Response{OK: true, Data: []byte{}}),
 	)
 
-	if err := doGet(ch, localDir, "/remote", []string{"get", "remote.txt", "dest"}, nil); err != nil {
+	if err := doGet(ch, localDir, "/remote", []string{"get", "remote.txt", "dest"}, true, nil); err != nil {
 		t.Fatalf("doGet error: %v", err)
 	}
 
@@ -2431,7 +2431,7 @@ func TestClientDoGetToNewLocalName(t *testing.T) {
 	)
 
 	newName := filepath.Join(localDir, "newname")
-	if err := doGet(ch, localDir, "/remote", []string{"get", "remote.txt", "newname"}, nil); err != nil {
+	if err := doGet(ch, localDir, "/remote", []string{"get", "remote.txt", "newname"}, true, nil); err != nil {
 		t.Fatalf("doGet error: %v", err)
 	}
 
@@ -2457,7 +2457,7 @@ func TestClientDoGetToAbsoluteTarget(t *testing.T) {
 		makeJSONDataMsg(&Response{OK: true, Data: []byte{}}),
 	)
 
-	if err := doGet(ch, localDir, "/remote", []string{"get", "remote.txt", target}, nil); err != nil {
+	if err := doGet(ch, localDir, "/remote", []string{"get", "remote.txt", target}, true, nil); err != nil {
 		t.Fatalf("doGet error: %v", err)
 	}
 

--- a/sftp/symlink_test.go
+++ b/sftp/symlink_test.go
@@ -1,0 +1,758 @@
+package sftp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	ssh3 "github.com/h4sh5/sshoq"
+	ssh3Messages "github.com/h4sh5/sshoq/message"
+	"github.com/h4sh5/sshoq/util"
+)
+
+// --- Server-side symlink reporting ---
+
+func TestServerStatSymlinkReportsTarget(t *testing.T) {
+	tmp := t.TempDir()
+	os.WriteFile(filepath.Join(tmp, "real.txt"), []byte("hello"), 0644)
+	if err := os.Symlink("real.txt", filepath.Join(tmp, "link.txt")); err != nil {
+		t.Skipf("cannot create symlink: %v", err)
+	}
+
+	sess := &ServerSession{currentDir: tmp}
+	resp := sess.handleRequest(Request{Cmd: "stat", Path: "link.txt"})
+	if !resp.OK {
+		t.Fatalf("stat failed: %s", resp.Error)
+	}
+	if resp.Info == nil || !resp.Info.IsSymlink {
+		t.Fatalf("expected symlink info, got %+v", resp.Info)
+	}
+	if resp.Info.LinkTarget != "real.txt" {
+		t.Fatalf("expected link target real.txt, got %q", resp.Info.LinkTarget)
+	}
+	if resp.Info.IsDir {
+		t.Fatalf("symlink must not be reported as a directory: %+v", resp.Info)
+	}
+	// The size is the link's own (lstat), not the target's.
+	if resp.Info.Size != int64(len("real.txt")) {
+		t.Fatalf("expected lstat size %d, got %d", len("real.txt"), resp.Info.Size)
+	}
+}
+
+func TestServerStatRegularFileNotSymlink(t *testing.T) {
+	tmp := t.TempDir()
+	os.WriteFile(filepath.Join(tmp, "real.txt"), []byte("hello"), 0644)
+
+	sess := &ServerSession{currentDir: tmp}
+	resp := sess.handleRequest(Request{Cmd: "stat", Path: "real.txt"})
+	if !resp.OK {
+		t.Fatalf("stat failed: %s", resp.Error)
+	}
+	if resp.Info == nil || resp.Info.IsSymlink || resp.Info.LinkTarget != "" {
+		t.Fatalf("unexpected symlink fields on regular file: %+v", resp.Info)
+	}
+}
+
+func TestServerLsSymlinkReportsTarget(t *testing.T) {
+	tmp := t.TempDir()
+	os.WriteFile(filepath.Join(tmp, "real.txt"), []byte("hello"), 0644)
+	if err := os.Symlink("real.txt", filepath.Join(tmp, "link.txt")); err != nil {
+		t.Skipf("cannot create symlink: %v", err)
+	}
+
+	sess := &ServerSession{currentDir: tmp}
+	resp := sess.handleRequest(Request{Cmd: "ls", Path: "."})
+	if !resp.OK {
+		t.Fatalf("ls failed: %s", resp.Error)
+	}
+	var link *FileInfo
+	for i := range resp.Entries {
+		if resp.Entries[i].Name == "link.txt" {
+			link = &resp.Entries[i]
+		}
+	}
+	if link == nil {
+		t.Fatalf("symlink entry missing: %+v", resp.Entries)
+	}
+	if !link.IsSymlink || link.LinkTarget != "real.txt" {
+		t.Fatalf("expected symlink entry with target real.txt, got %+v", link)
+	}
+	if link.IsDir {
+		t.Fatalf("symlink must not be reported as a directory: %+v", link)
+	}
+}
+
+func TestServerGetSymlinkNotFollowedServerSide(t *testing.T) {
+	tmp := t.TempDir()
+	os.WriteFile(filepath.Join(tmp, "real.txt"), []byte("hello"), 0644)
+	if err := os.Symlink("real.txt", filepath.Join(tmp, "link.txt")); err != nil {
+		t.Skipf("cannot create symlink: %v", err)
+	}
+
+	sess := &ServerSession{currentDir: tmp}
+	// The server does not follow: it reports links via stat/ls and reads the
+	// resolved path the client sends. A raw get on a symlink fails (ELOOP).
+	resp := sess.handleRequest(Request{Cmd: "get", Path: "link.txt"})
+	if resp.OK || resp.Error == "" {
+		t.Fatalf("expected get of a symlink to fail server-side, got %+v", resp)
+	}
+	if len(resp.Data) != 0 {
+		t.Fatalf("expected no data from a symlink get, got %q", resp.Data)
+	}
+}
+
+// --- Client-side download: following server symlinks ---
+
+func TestDownloadFileFollowsServerSymlink(t *testing.T) {
+	tmp := t.TempDir()
+	localPath := filepath.Join(tmp, "out.txt")
+
+	// stat link.txt -> symlink to real.txt; stat real.txt -> regular file.
+	ch := newMockChannel(
+		makeJSONDataMsg(&Response{ID: 1, OK: true, Info: &FileInfo{Name: "link.txt", IsSymlink: true, LinkTarget: "real.txt"}}),
+		makeJSONDataMsg(&Response{ID: 2, OK: true, Info: &FileInfo{Name: "real.txt", Size: 5}}),
+		makeJSONDataMsg(&Response{ID: 3, OK: true, Data: []byte("hello")}),
+		makeJSONDataMsg(&Response{ID: 4, OK: true, Data: []byte{}}),
+	)
+
+	if err := downloadFile(ch, "/remote/link.txt", localPath, true, nil); err != nil {
+		t.Fatalf("downloadFile error: %v", err)
+	}
+
+	got, err := os.ReadFile(localPath)
+	if err != nil {
+		t.Fatalf("read error: %v", err)
+	}
+	if string(got) != "hello" {
+		t.Fatalf("unexpected content: %q", got)
+	}
+
+	// The client must have asked the server for the resolved path, not the
+	// link itself: the initial stat names the link, the get requests name the
+	// resolved target so the server reads the regular file.
+	if len(ch.Writes) != 4 {
+		t.Fatalf("expected 4 requests, got %d", len(ch.Writes))
+	}
+	var req Request
+	if err := json.Unmarshal(ch.Writes[0], &req); err != nil {
+		t.Fatalf("unmarshal stat: %v", err)
+	}
+	if req.Cmd != "stat" || req.Path != "/remote/link.txt" {
+		t.Fatalf("expected stat /remote/link.txt, got %s %q", req.Cmd, req.Path)
+	}
+	if err := json.Unmarshal(ch.Writes[1], &req); err != nil {
+		t.Fatalf("unmarshal stat: %v", err)
+	}
+	if req.Cmd != "stat" || req.Path != "/remote/real.txt" {
+		t.Fatalf("expected stat /remote/real.txt, got %s %q", req.Cmd, req.Path)
+	}
+	if err := json.Unmarshal(ch.Writes[2], &req); err != nil {
+		t.Fatalf("unmarshal get: %v", err)
+	}
+	if req.Cmd != "get" || req.Path != "/remote/real.txt" {
+		t.Fatalf("expected get /remote/real.txt, got %s %q", req.Cmd, req.Path)
+	}
+}
+
+func TestDownloadFileFollowsRelativeAndAbsoluteTargets(t *testing.T) {
+	localPath := filepath.Join(t.TempDir(), "out.txt")
+
+	// link -> ../other/real.txt (relative to the link's directory).
+	ch := newMockChannel(
+		makeJSONDataMsg(&Response{ID: 1, OK: true, Info: &FileInfo{Name: "link", IsSymlink: true, LinkTarget: "../other/real.txt"}}),
+		makeJSONDataMsg(&Response{ID: 2, OK: true, Info: &FileInfo{Name: "real.txt", Size: 4}}),
+		makeJSONDataMsg(&Response{ID: 3, OK: true, Data: []byte("data")}),
+		makeJSONDataMsg(&Response{ID: 4, OK: true, Data: []byte{}}),
+	)
+	if err := downloadFile(ch, "/home/u/sub/link", localPath, true, nil); err != nil {
+		t.Fatalf("downloadFile (relative target) error: %v", err)
+	}
+	var req Request
+	if err := json.Unmarshal(ch.Writes[1], &req); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if req.Path != "/home/u/other/real.txt" {
+		t.Fatalf("expected resolved relative target /home/u/other/real.txt, got %q", req.Path)
+	}
+
+	// link -> /etc/passwd (absolute target used verbatim).
+	ch2 := newMockChannel(
+		makeJSONDataMsg(&Response{ID: 1, OK: true, Info: &FileInfo{Name: "link", IsSymlink: true, LinkTarget: "/etc/passwd"}}),
+		makeJSONDataMsg(&Response{ID: 2, OK: true, Info: &FileInfo{Name: "passwd", Size: 4}}),
+		makeJSONDataMsg(&Response{ID: 3, OK: true, Data: []byte("data")}),
+		makeJSONDataMsg(&Response{ID: 4, OK: true, Data: []byte{}}),
+	)
+	if err := downloadFile(ch2, "/home/u/link", localPath, true, nil); err != nil {
+		t.Fatalf("downloadFile (absolute target) error: %v", err)
+	}
+	if err := json.Unmarshal(ch2.Writes[1], &req); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if req.Path != "/etc/passwd" {
+		t.Fatalf("expected absolute target /etc/passwd, got %q", req.Path)
+	}
+}
+
+func TestDownloadFileNoFollowRejectsServerSymlink(t *testing.T) {
+	ch := newMockChannel(
+		makeJSONDataMsg(&Response{ID: 1, OK: true, Info: &FileInfo{Name: "link.txt", IsSymlink: true, LinkTarget: "real.txt"}}),
+	)
+
+	err := downloadFile(ch, "/remote/link.txt", filepath.Join(t.TempDir(), "out"), false, nil)
+	if err == nil {
+		t.Fatal("expected error for no-follow download of a symlink")
+	}
+	if !strings.Contains(err.Error(), "symbolic link") {
+		t.Fatalf("expected 'symbolic link' error, got %v", err)
+	}
+	// Only the initial stat was sent: no follow, no transfer.
+	if len(ch.Writes) != 1 {
+		t.Fatalf("expected only the stat request, got %d", len(ch.Writes))
+	}
+}
+
+func TestDownloadFileFollowSymlinkLoop(t *testing.T) {
+	// link -> itself: the client must give up after the follow limit. The mock
+	// returns the same symlink for each of the fatal-link resolution hops.
+	var msgs []ssh3Messages.Message
+	for i := 0; i < maxSymlinkFollow; i++ {
+		msgs = append(msgs, makeJSONDataMsg(&Response{ID: uint64(i + 1), OK: true, Info: &FileInfo{Name: "loop", IsSymlink: true, LinkTarget: "loop"}}))
+	}
+	ch := newMockChannel(msgs...)
+	err := downloadFile(ch, "/remote/loop", filepath.Join(t.TempDir(), "out"), true, nil)
+	if err == nil {
+		t.Fatal("expected error for symlink loop")
+	}
+	if !strings.Contains(err.Error(), "too many levels of symbolic links") {
+		t.Fatalf("expected symlink loop error, got %v", err)
+	}
+}
+
+func TestDownloadRecursiveFollowsServerSymlinkToDir(t *testing.T) {
+	tmp := t.TempDir()
+	localRoot := filepath.Join(tmp, "downloaded")
+
+	// remote-dir/ contains a symlink "dirlink" -> "sub" (a directory).
+	ch := newMockChannel(
+		makeJSONDataMsg(&Response{ID: 1, OK: true, Info: &FileInfo{Name: "remote-dir", IsDir: true}}),
+		makeJSONDataMsg(&Response{ID: 2, OK: true, Entries: []FileInfo{
+			{Name: "file.txt", Size: 5, Mode: 0644},
+			{Name: "dirlink", IsSymlink: true, LinkTarget: "sub"},
+		}}),
+		makeJSONDataMsg(&Response{ID: 3, OK: true, Data: []byte("hello")}),
+		makeJSONDataMsg(&Response{ID: 4, OK: true, Data: []byte{}}),
+		// Following dirlink: stat resolves sub, ls sub.
+		makeJSONDataMsg(&Response{ID: 5, OK: true, Info: &FileInfo{Name: "sub", IsDir: true}}),
+		makeJSONDataMsg(&Response{ID: 6, OK: true, Entries: []FileInfo{{Name: "nested.txt", Size: 11, Mode: 0644}}}),
+		makeJSONDataMsg(&Response{ID: 7, OK: true, Data: []byte("hello world")}),
+		makeJSONDataMsg(&Response{ID: 8, OK: true, Data: []byte{}}),
+	)
+
+	if err := downloadRecursive(ch, "remote-dir", localRoot, true, nil); err != nil {
+		t.Fatalf("downloadRecursive error: %v", err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(localRoot, "file.txt"))
+	if err != nil {
+		t.Fatalf("read file.txt: %v", err)
+	}
+	if string(got) != "hello" {
+		t.Fatalf("unexpected file.txt content: %q", got)
+	}
+	nested, err := os.ReadFile(filepath.Join(localRoot, "dirlink", "nested.txt"))
+	if err != nil {
+		t.Fatalf("read dirlink/nested.txt: %v", err)
+	}
+	if string(nested) != "hello world" {
+		t.Fatalf("unexpected dirlink/nested.txt content: %q", nested)
+	}
+}
+
+func TestDownloadRecursiveNoFollowRejectsServerSymlink(t *testing.T) {
+	localRoot := filepath.Join(t.TempDir(), "downloaded")
+
+	ch := newMockChannel(
+		makeJSONDataMsg(&Response{ID: 1, OK: true, Info: &FileInfo{Name: "remote-dir", IsDir: true}}),
+		// The symlink entry comes first so it is rejected before any file chunk
+		// request is attempted.
+		makeJSONDataMsg(&Response{ID: 2, OK: true, Entries: []FileInfo{
+			{Name: "dirlink", IsSymlink: true, LinkTarget: "sub"},
+			{Name: "file.txt", Size: 5, Mode: 0644},
+		}}),
+	)
+
+	err := downloadRecursive(ch, "remote-dir", localRoot, false, nil)
+	if err == nil {
+		t.Fatal("expected error for no-follow recursive download of a symlink")
+	}
+	if !strings.Contains(err.Error(), "symbolic link") {
+		t.Fatalf("expected 'symbolic link' error, got %v", err)
+	}
+}
+
+// --- Client-side upload: following local symlinks ---
+
+func TestUploadFileFollowsLocalSymlink(t *testing.T) {
+	tmp := t.TempDir()
+	os.WriteFile(filepath.Join(tmp, "real.txt"), []byte("upload me"), 0644)
+	if err := os.Symlink("real.txt", filepath.Join(tmp, "link.txt")); err != nil {
+		t.Skipf("cannot create symlink: %v", err)
+	}
+
+	ch := newMockChannel(makeJSONDataMsg(&Response{ID: 1, OK: true}))
+
+	if err := uploadFile(ch, filepath.Join(tmp, "link.txt"), "/remote/link.txt", true, nil); err != nil {
+		t.Fatalf("uploadFile error: %v", err)
+	}
+	if len(ch.Writes) != 1 {
+		t.Fatalf("expected 1 request, got %d", len(ch.Writes))
+	}
+	// The target's content must be uploaded, not the link itself.
+	var req Request
+	if err := json.Unmarshal(ch.Writes[0], &req); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if string(req.Data) != "upload me" {
+		t.Fatalf("expected target content, got %q", req.Data)
+	}
+}
+
+func TestUploadFileNoFollowRejectsLocalSymlink(t *testing.T) {
+	tmp := t.TempDir()
+	os.WriteFile(filepath.Join(tmp, "real.txt"), []byte("upload me"), 0644)
+	if err := os.Symlink("real.txt", filepath.Join(tmp, "link.txt")); err != nil {
+		t.Skipf("cannot create symlink: %v", err)
+	}
+
+	ch := newMockChannel()
+	err := uploadFile(ch, filepath.Join(tmp, "link.txt"), "/remote/link.txt", false, nil)
+	if err == nil {
+		t.Fatal("expected error for no-follow upload of a symlink")
+	}
+	if !strings.Contains(err.Error(), "symbolic link") {
+		t.Fatalf("expected 'symbolic link' error, got %v", err)
+	}
+	if len(ch.Writes) != 0 {
+		t.Fatalf("expected no requests, got %d", len(ch.Writes))
+	}
+}
+
+func TestUploadRecursiveFollowsLocalSymlinkToDir(t *testing.T) {
+	tmp := t.TempDir()
+	localRoot := filepath.Join(tmp, "src")
+	os.MkdirAll(filepath.Join(localRoot, "sub"), 0o755)
+	os.WriteFile(filepath.Join(localRoot, "file.txt"), []byte("hello"), 0644)
+	os.WriteFile(filepath.Join(localRoot, "sub", "nested.txt"), []byte("world"), 0644)
+	if err := os.Symlink("sub", filepath.Join(localRoot, "dirlink")); err != nil {
+		t.Skipf("cannot create symlink: %v", err)
+	}
+
+	// os.ReadDir returns entries sorted by name: dirlink, file.txt, sub.
+	// Request sequence (follow=true):
+	//   ensureRemoteDir("remote-dir"):
+	//     stat("remote-dir") -> miss
+	//     mkdir("remote-dir") -> ok
+	//   recurse into dirlink: ensureRemoteDir("remote-dir/dirlink"):
+	//     stat("remote-dir/dirlink") -> miss
+	//     stat("remote-dir") -> dir
+	//     mkdir("remote-dir/dirlink") -> ok
+	//   upload nested.txt: put("remote-dir/dirlink/nested.txt") -> ok
+	//   upload file.txt: put("remote-dir/file.txt") -> ok
+	//   recurse into sub: ensureRemoteDir("remote-dir/sub"):
+	//     stat("remote-dir/sub") -> miss
+	//     stat("remote-dir") -> dir
+	//     mkdir("remote-dir/sub") -> ok
+	//   upload nested.txt: put("remote-dir/sub/nested.txt") -> ok
+	ch := newMockChannel(
+		makeJSONDataMsg(&Response{ID: 1, OK: false, Error: "no such file"}),
+		makeJSONDataMsg(&Response{ID: 2, OK: true}),
+		makeJSONDataMsg(&Response{ID: 3, OK: false, Error: "no such file"}),
+		makeJSONDataMsg(&Response{ID: 4, OK: true, Info: &FileInfo{Name: "remote-dir", IsDir: true}}),
+		makeJSONDataMsg(&Response{ID: 5, OK: true}),
+		makeJSONDataMsg(&Response{ID: 6, OK: true}),
+		makeJSONDataMsg(&Response{ID: 7, OK: true}),
+		makeJSONDataMsg(&Response{ID: 8, OK: false, Error: "no such file"}),
+		makeJSONDataMsg(&Response{ID: 9, OK: true, Info: &FileInfo{Name: "remote-dir", IsDir: true}}),
+		makeJSONDataMsg(&Response{ID: 10, OK: true}),
+		makeJSONDataMsg(&Response{ID: 11, OK: true}),
+	)
+
+	if err := uploadRecursive(ch, localRoot, "remote-dir", true, nil); err != nil {
+		t.Fatalf("uploadRecursive error: %v", err)
+	}
+	if len(ch.Writes) != 11 {
+		t.Fatalf("expected 11 requests, got %d: %v", len(ch.Writes), requestPaths(ch.Writes))
+	}
+
+	// The symlinked directory's file must be uploaded under dirlink/.
+	var putReq Request
+	found := false
+	for _, w := range ch.Writes {
+		if err := json.Unmarshal(w, &putReq); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if putReq.Cmd == "put" && putReq.Path == "remote-dir/dirlink/nested.txt" {
+			found = true
+			if string(putReq.Data) != "world" {
+				t.Fatalf("expected nested content, got %q", putReq.Data)
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("expected put remote-dir/dirlink/nested.txt, requests: %v", requestPaths(ch.Writes))
+	}
+}
+
+func TestUploadRecursiveNoFollowRejectsLocalSymlink(t *testing.T) {
+	tmp := t.TempDir()
+	localRoot := filepath.Join(tmp, "src")
+	os.MkdirAll(localRoot, 0o755)
+	os.WriteFile(filepath.Join(localRoot, "file.txt"), []byte("hello"), 0644)
+	if err := os.Symlink("sub", filepath.Join(localRoot, "dirlink")); err != nil {
+		t.Skipf("cannot create symlink: %v", err)
+	}
+
+	// The child "dirlink" is reached only after the remote root directory is
+	// ensured (stat miss, then mkdir). With follow=false it is then rejected
+	// as a symbolic link.
+	ch := newMockChannel(
+		makeJSONDataMsg(&Response{ID: 1, OK: false, Error: "no such file"}),
+		makeJSONDataMsg(&Response{ID: 2, OK: true}),
+	)
+	err := uploadRecursive(ch, localRoot, "remote-dir", false, nil)
+	if err == nil {
+		t.Fatal("expected error for no-follow recursive upload of a symlink")
+	}
+	if !strings.Contains(err.Error(), "symbolic link") {
+		t.Fatalf("expected 'symbolic link' error, got %v", err)
+	}
+}
+
+// requestPaths decodes the requests recorded on a channel into their paths,
+// for readable failure messages.
+func requestPaths(writes [][]byte) []string {
+	var out []string
+	for _, w := range writes {
+		var req Request
+		if err := json.Unmarshal(w, &req); err != nil {
+			out = append(out, "<unparseable>")
+			continue
+		}
+		out = append(out, req.Cmd+":"+req.Path)
+	}
+	return out
+}
+
+// --- End-to-end: real server session against the client transfer functions ---
+
+// pipeChannel is one end of an in-memory byte pipe pair that connects the SFTP
+// client transfer functions to a live ServerSession in the same process:
+// messages written to one end are delivered to the other end's NextMessage,
+// mirroring the QUIC channel. It embeds *ssh3.MockChannel so the unexported
+// interface methods (addDatagram, confirmChannel, ...) are promoted from a type
+// in package ssh3 and the result satisfies ssh3.Channel; the exported routing
+// methods are overridden to provide the live pipe. Writes are recorded for
+// assertions.
+type pipeChannel struct {
+	*ssh3.MockChannel
+	incoming chan ssh3Messages.Message
+	peer     *pipeChannel
+	closed   chan struct{}
+	once     sync.Once
+
+	mu     sync.Mutex
+	writes [][]byte
+}
+
+func newPipePair() (*pipeChannel, *pipeChannel) {
+	a := &pipeChannel{
+		MockChannel: ssh3.NewMockChannel(),
+		incoming:    make(chan ssh3Messages.Message, 64),
+		closed:      make(chan struct{}),
+	}
+	b := &pipeChannel{
+		MockChannel: ssh3.NewMockChannel(),
+		incoming:    make(chan ssh3Messages.Message, 64),
+		closed:      make(chan struct{}),
+	}
+	a.peer = b
+	b.peer = a
+	return a, b
+}
+
+func (p *pipeChannel) NextMessage() (ssh3Messages.Message, error) {
+	select {
+	case msg, ok := <-p.incoming:
+		if !ok {
+			return nil, io.EOF
+		}
+		return msg, nil
+	case <-p.closed:
+		return nil, io.EOF
+	}
+}
+
+func (p *pipeChannel) WriteData(dataBuf []byte, dataType ssh3Messages.SSHDataType) (int, error) {
+	if dataType != ssh3Messages.SSH_EXTENDED_DATA_NONE {
+		return 0, fmt.Errorf("extended data not supported")
+	}
+	p.mu.Lock()
+	p.writes = append(p.writes, append([]byte(nil), dataBuf...))
+	p.mu.Unlock()
+	msg := &ssh3Messages.DataOrExtendedDataMessage{DataType: ssh3Messages.SSH_EXTENDED_DATA_NONE, Data: string(dataBuf)}
+	select {
+	case p.peer.incoming <- msg:
+		return len(dataBuf), nil
+	case <-p.peer.closed:
+		return 0, io.EOF
+	}
+}
+
+// Close signals the peer that no more messages will be sent in this
+// direction, so its NextMessage returns EOF.
+func (p *pipeChannel) Close() {
+	p.MockChannel.Close()
+	p.once.Do(func() { close(p.closed) })
+}
+
+func (p *pipeChannel) Writes() [][]byte {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return append([][]byte(nil), p.writes...)
+}
+
+func (p *pipeChannel) ChannelID() util.ChannelID           { return 0 }
+func (p *pipeChannel) ConversationID() ssh3.ConversationID { return ssh3.ConversationID{} }
+func (p *pipeChannel) ConversationStreamID() uint64        { return 0 }
+func (p *pipeChannel) ReceiveDatagram(_ context.Context) ([]byte, error) {
+	return nil, io.EOF
+}
+func (p *pipeChannel) SendDatagram(_ []byte) error                             { return fmt.Errorf("not supported") }
+func (p *pipeChannel) SendRequest(_ *ssh3Messages.ChannelRequestMessage) error { return nil }
+func (p *pipeChannel) CancelRead()                                             {}
+func (p *pipeChannel) MaxPacketSize() uint64                                   { return 1 << 20 }
+func (p *pipeChannel) ChannelType() string                                     { return "sftp" }
+func (p *pipeChannel) WaitOpen() error                                         { return nil }
+func (p *pipeChannel) RejectOpen(_ uint64, _ string) error                     { return fmt.Errorf("not supported") }
+func (p *pipeChannel) confirmChannel(_ uint64) error                           { return nil }
+func (p *pipeChannel) setDatagramSender(_ func([]byte) error)                  {}
+func (p *pipeChannel) waitAddDatagram(_ context.Context, _ []byte) error       { return nil }
+func (p *pipeChannel) addDatagram(datagram []byte) bool                        { return true }
+func (p *pipeChannel) maybeSendHeader() error                                  { return nil }
+func (p *pipeChannel) setDgramQueue(_ *util.DatagramsQueue)                    {}
+
+// servePipe runs a real server session on serverEnd in the background,
+// returning a function that closes the client end and waits for the server to
+// exit.
+func servePipe(t *testing.T, serverEnd *pipeChannel, remoteDir string) func() {
+	t.Helper()
+	done := make(chan struct{})
+	go func() {
+		serveChannelInProcess(context.Background(), currentTestUser(remoteDir), serverEnd)
+		close(done)
+	}()
+	return func() {
+		serverEnd.Close()
+		<-done
+	}
+}
+
+func TestEndToEndGetServerSymlink(t *testing.T) {
+	remoteDir := t.TempDir()
+	os.WriteFile(filepath.Join(remoteDir, "real.txt"), []byte("hello world"), 0644)
+	if err := os.Symlink("real.txt", filepath.Join(remoteDir, "link.txt")); err != nil {
+		t.Skipf("cannot create symlink: %v", err)
+	}
+	localDir := t.TempDir()
+
+	clientEnd, serverEnd := newPipePair()
+	stop := servePipe(t, serverEnd, remoteDir)
+	defer stop()
+
+	// The client resolves the server-side link by asking the server for its
+	// target, then reads the resolved file.
+	if err := doGet(clientEnd, localDir, remoteDir, []string{"get", "link.txt"}, true, nil); err != nil {
+		t.Fatalf("doGet error: %v", err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(localDir, "link.txt"))
+	if err != nil {
+		t.Fatalf("read downloaded file: %v", err)
+	}
+	if string(got) != "hello world" {
+		t.Fatalf("unexpected content: %q", got)
+	}
+
+	// The transfer must have read the resolved target, not the link.
+	paths := requestPaths(clientEnd.Writes())
+	if !containsPath(paths, "get:"+filepath.Join(remoteDir, "real.txt")) {
+		t.Fatalf("expected a get of the resolved target, requests: %v", paths)
+	}
+}
+
+func TestEndToEndGetServerSymlinkNoFollow(t *testing.T) {
+	remoteDir := t.TempDir()
+	os.WriteFile(filepath.Join(remoteDir, "real.txt"), []byte("hello world"), 0644)
+	if err := os.Symlink("real.txt", filepath.Join(remoteDir, "link.txt")); err != nil {
+		t.Skipf("cannot create symlink: %v", err)
+	}
+	localDir := t.TempDir()
+
+	clientEnd, serverEnd := newPipePair()
+	stop := servePipe(t, serverEnd, remoteDir)
+	defer stop()
+
+	err := doGet(clientEnd, localDir, remoteDir, []string{"get", "link.txt"}, false, nil)
+	if err == nil {
+		t.Fatal("expected no-follow get of a symlink to fail")
+	}
+	if !strings.Contains(err.Error(), "symbolic link") {
+		t.Fatalf("expected 'symbolic link' error, got %v", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(localDir, "link.txt")); !os.IsNotExist(statErr) {
+		t.Fatalf("no file should have been downloaded, stat error: %v", statErr)
+	}
+}
+
+func TestEndToEndGetRecursiveFollowsServerSymlink(t *testing.T) {
+	remoteDir := t.TempDir()
+	os.MkdirAll(filepath.Join(remoteDir, "rdir", "sub"), 0o755)
+	os.WriteFile(filepath.Join(remoteDir, "rdir", "file.txt"), []byte("hello"), 0644)
+	os.WriteFile(filepath.Join(remoteDir, "rdir", "sub", "nested.txt"), []byte("world"), 0644)
+	if err := os.Symlink("sub", filepath.Join(remoteDir, "rdir", "dirlink")); err != nil {
+		t.Skipf("cannot create symlink: %v", err)
+	}
+	localDir := t.TempDir()
+
+	clientEnd, serverEnd := newPipePair()
+	stop := servePipe(t, serverEnd, remoteDir)
+	defer stop()
+
+	if err := doGet(clientEnd, localDir, remoteDir, []string{"get", "-r", "rdir"}, true, nil); err != nil {
+		t.Fatalf("doGet -r error: %v", err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(localDir, "rdir", "file.txt"))
+	if err != nil || string(got) != "hello" {
+		t.Fatalf("file.txt: content %q err %v", got, err)
+	}
+	nested, err := os.ReadFile(filepath.Join(localDir, "rdir", "dirlink", "nested.txt"))
+	if err != nil || string(nested) != "world" {
+		t.Fatalf("dirlink/nested.txt: content %q err %v", nested, err)
+	}
+}
+
+func TestEndToEndPutClientSymlink(t *testing.T) {
+	remoteDir := t.TempDir()
+	localDir := t.TempDir()
+	os.WriteFile(filepath.Join(localDir, "real.txt"), []byte("upload me"), 0644)
+	if err := os.Symlink("real.txt", filepath.Join(localDir, "link.txt")); err != nil {
+		t.Skipf("cannot create symlink: %v", err)
+	}
+
+	clientEnd, serverEnd := newPipePair()
+	stop := servePipe(t, serverEnd, remoteDir)
+	defer stop()
+
+	// The client follows the local link and uploads its target's content.
+	if err := doPut(clientEnd, localDir, remoteDir, []string{"put", "link.txt"}, true, nil); err != nil {
+		t.Fatalf("doPut error: %v", err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(remoteDir, "link.txt"))
+	if err != nil {
+		t.Fatalf("read uploaded file: %v", err)
+	}
+	if string(got) != "upload me" {
+		t.Fatalf("unexpected content: %q", got)
+	}
+}
+
+func TestEndToEndPutClientSymlinkNoFollow(t *testing.T) {
+	remoteDir := t.TempDir()
+	localDir := t.TempDir()
+	os.WriteFile(filepath.Join(localDir, "real.txt"), []byte("upload me"), 0644)
+	if err := os.Symlink("real.txt", filepath.Join(localDir, "link.txt")); err != nil {
+		t.Skipf("cannot create symlink: %v", err)
+	}
+
+	clientEnd, serverEnd := newPipePair()
+	stop := servePipe(t, serverEnd, remoteDir)
+	defer stop()
+
+	err := doPut(clientEnd, localDir, remoteDir, []string{"put", "link.txt"}, false, nil)
+	if err == nil {
+		t.Fatal("expected no-follow put of a symlink to fail")
+	}
+	if !strings.Contains(err.Error(), "symbolic link") {
+		t.Fatalf("expected 'symbolic link' error, got %v", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(remoteDir, "link.txt")); !os.IsNotExist(statErr) {
+		t.Fatalf("no file should have been uploaded, stat error: %v", statErr)
+	}
+}
+
+func TestEndToEndPutRecursiveFollowsClientSymlink(t *testing.T) {
+	remoteDir := t.TempDir()
+	localDir := t.TempDir()
+	os.MkdirAll(filepath.Join(localDir, "ldir", "sub"), 0o755)
+	os.WriteFile(filepath.Join(localDir, "ldir", "file.txt"), []byte("hello"), 0644)
+	os.WriteFile(filepath.Join(localDir, "ldir", "sub", "nested.txt"), []byte("world"), 0644)
+	if err := os.Symlink("sub", filepath.Join(localDir, "ldir", "dirlink")); err != nil {
+		t.Skipf("cannot create symlink: %v", err)
+	}
+
+	clientEnd, serverEnd := newPipePair()
+	stop := servePipe(t, serverEnd, remoteDir)
+	defer stop()
+
+	if err := doPut(clientEnd, localDir, remoteDir, []string{"put", "-r", "ldir"}, true, nil); err != nil {
+		t.Fatalf("doPut -r error: %v", err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(remoteDir, "ldir", "file.txt"))
+	if err != nil || string(got) != "hello" {
+		t.Fatalf("file.txt: content %q err %v", got, err)
+	}
+	nested, err := os.ReadFile(filepath.Join(remoteDir, "ldir", "dirlink", "nested.txt"))
+	if err != nil || string(nested) != "world" {
+		t.Fatalf("dirlink/nested.txt: content %q err %v", nested, err)
+	}
+}
+
+func TestEndToEndGetSymlinkToAbsolutePath(t *testing.T) {
+	remoteDir := t.TempDir()
+	target := filepath.Join(remoteDir, "elsewhere.txt")
+	os.WriteFile(target, []byte("absolute"), 0644)
+	if err := os.Symlink(target, filepath.Join(remoteDir, "abslink.txt")); err != nil {
+		t.Skipf("cannot create symlink: %v", err)
+	}
+	localDir := t.TempDir()
+
+	clientEnd, serverEnd := newPipePair()
+	stop := servePipe(t, serverEnd, remoteDir)
+	defer stop()
+
+	if err := doGet(clientEnd, localDir, remoteDir, []string{"get", "abslink.txt"}, true, nil); err != nil {
+		t.Fatalf("doGet error: %v", err)
+	}
+	got, err := os.ReadFile(filepath.Join(localDir, "abslink.txt"))
+	if err != nil || string(got) != "absolute" {
+		t.Fatalf("abslink.txt: content %q err %v", got, err)
+	}
+}
+
+func containsPath(paths []string, want string) bool {
+	for _, p := range paths {
+		if p == want {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Symlink resolution now happens on the client: the server reports each symbolic link via stat/ls (IsSymlink + LinkTarget, the "next link to follow") and the client resolves server-side links for get and local links for put, one hop at a time and capped at 40 hops like the kernel's ELOOP limit. Following is the default for both directions, including recursive transfers (get -r descends into server symlinked directories, put -r follows local symlinked directories), so get of a server symlink and put of a client symlink transfer the link targets' contents.

The new -no-follow-symlinks switch (client, -sftp mode) disables client-side following: get refuses to download a server symlink and put refuses to upload a client symlink, matching OpenSSH's get/put -P.

cd and ls follow symlinked directories server-side like OpenSSH, while get/put keep O_NOFOLLOW since the client resolves first.

Adds server/client unit tests plus end-to-end tests running a live ServerSession against the client transfer functions over an in-memory pipe channel.