### PR TITLE
perf: replace JSON sftp protocol with a compact binary format

### DIFF
--- a/sftp/cancel_test.go
+++ b/sftp/cancel_test.go
@@ -59,7 +59,7 @@ func TestUploadFileCancelled(t *testing.T) {
 
 	cancel := &transferCancel{}
 	ch := &cancellingChannel{
-		MockChannel: newMockChannel(makeJSONDataMsg(&Response{ID: 1, OK: true})),
+		MockChannel: newMockChannel(makeResponseMsg(&Response{ID: 1, OK: true})),
 		cancel:      cancel,
 		cancelAt:    1, // interrupt as soon as the first chunk is sent
 	}
@@ -104,8 +104,8 @@ func TestDownloadFileCancelled(t *testing.T) {
 	cancel := &transferCancel{}
 	ch := &cancellingChannel{
 		MockChannel: newMockChannel(
-			makeJSONDataMsg(&Response{ID: 1, OK: true, Info: &FileInfo{Name: "remote.bin", Size: int64(ChunkSize * 4)}}),
-			makeJSONDataMsg(&Response{ID: 2, OK: true, Data: chunk}),
+			makeResponseMsg(&Response{ID: 1, OK: true, Info: &FileInfo{Name: "remote.bin", Size: int64(ChunkSize * 4)}}),
+			makeResponseMsg(&Response{ID: 2, OK: true, Data: chunk}),
 		),
 		cancel:   cancel,
 		cancelAt: 2, // interrupt as soon as the first get request is sent

--- a/sftp/client.go
+++ b/sftp/client.go
@@ -1354,11 +1354,14 @@ func uploadFile(channel ssh3.Channel, localPath, remotePath string, follow bool,
 	// position and returns the bytes and the file offset at which they were
 	// read. The offset is sent to the server so it writes at the right spot;
 	// io.ReadFull guarantees every chunk except a short final one is a full
-	// ChunkSize, so the offsets stay aligned with the server's writes.
+	// ChunkSize, so the offsets stay aligned with the server's writes. The
+	// chunk buffer is allocated once and reused: SendRequest copies the data
+	// into its frame synchronously, so the next read cannot clobber a chunk
+	// that is still in flight.
 	filePos := int64(0)
+	chunkBuf := make([]byte, ChunkSize)
 	readChunk := func() ([]byte, int64, error) {
-		buf := make([]byte, ChunkSize)
-		n, err := io.ReadFull(f, buf)
+		n, err := io.ReadFull(f, chunkBuf)
 		if err != nil && err != io.ErrUnexpectedEOF && err != io.EOF {
 			return nil, 0, err
 		}
@@ -1367,7 +1370,7 @@ func uploadFile(channel ssh3.Channel, localPath, remotePath string, follow bool,
 		if n == 0 {
 			return nil, off, nil // EOF: no more data
 		}
-		return buf[:n], off, nil
+		return chunkBuf[:n], off, nil
 	}
 
 	// Issue the initial window of write requests.

--- a/sftp/completer_test.go
+++ b/sftp/completer_test.go
@@ -3,7 +3,6 @@ package sftp
 import (
 	"bufio"
 	"bytes"
-	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -62,7 +61,7 @@ func remoteEntries(entries ...FileInfo) []FileInfo {
 }
 
 func TestCompleterRemote(t *testing.T) {
-	resp := makeJSONDataMsg(&Response{OK: true, Entries: remoteEntries(
+	resp := makeResponseMsg(&Response{OK: true, Entries: remoteEntries(
 		FileInfo{Name: "docs", IsDir: true},
 		FileInfo{Name: "file1.txt"},
 		FileInfo{Name: "file2.txt"},
@@ -81,7 +80,7 @@ func TestCompleterRemote(t *testing.T) {
 		t.Errorf("candidates = %v, want [file1.txt file2.txt]", cands)
 	}
 	var got Request
-	if err := json.Unmarshal(ch.Writes[0], &got); err != nil {
+	if err := decodeRequestFrame(ch.Writes[0], &got); err != nil {
 		t.Fatalf("unmarshal request: %v", err)
 	}
 	if got.Cmd != "ls" || got.Path != "/remote" {
@@ -112,7 +111,7 @@ func TestCompleterRemote(t *testing.T) {
 }
 
 func TestCompleterRemoteTrailingSlashListsDir(t *testing.T) {
-	ch := newMockChannel(makeJSONDataMsg(&Response{OK: true, Entries: remoteEntries(
+	ch := newMockChannel(makeResponseMsg(&Response{OK: true, Entries: remoteEntries(
 		FileInfo{Name: "main.go"},
 		FileInfo{Name: "util.go"},
 	)}))
@@ -128,7 +127,7 @@ func TestCompleterRemoteTrailingSlashListsDir(t *testing.T) {
 		t.Errorf("candidates = %v, want [docs/main.go]", cands)
 	}
 	var got Request
-	if err := json.Unmarshal(ch.Writes[0], &got); err != nil {
+	if err := decodeRequestFrame(ch.Writes[0], &got); err != nil {
 		t.Fatalf("unmarshal request: %v", err)
 	}
 	if got.Path != "/remote/docs" {
@@ -137,7 +136,7 @@ func TestCompleterRemoteTrailingSlashListsDir(t *testing.T) {
 }
 
 func TestCompleterRemoteAbsolute(t *testing.T) {
-	ch := newMockChannel(makeJSONDataMsg(&Response{OK: true, Entries: remoteEntries(
+	ch := newMockChannel(makeResponseMsg(&Response{OK: true, Entries: remoteEntries(
 		FileInfo{Name: "var"},
 		FileInfo{Name: "usr", IsDir: true},
 	)}))
@@ -149,7 +148,7 @@ func TestCompleterRemoteAbsolute(t *testing.T) {
 		t.Errorf("absolute candidates = %v, want [/usr/]", cands)
 	}
 	var got Request
-	if err := json.Unmarshal(ch.Writes[0], &got); err != nil {
+	if err := decodeRequestFrame(ch.Writes[0], &got); err != nil {
 		t.Fatalf("unmarshal request: %v", err)
 	}
 	if got.Path != "/" {
@@ -158,7 +157,7 @@ func TestCompleterRemoteAbsolute(t *testing.T) {
 }
 
 func TestCompleterRemoteError(t *testing.T) {
-	ch := newMockChannel(makeJSONDataMsg(&Response{OK: false, Error: "no such file"}))
+	ch := newMockChannel(makeResponseMsg(&Response{OK: false, Error: "no such file"}))
 	localDir, remoteDir := "/local", "/remote"
 	c := newCompleter(ch, &localDir, &remoteDir)
 
@@ -197,10 +196,10 @@ func TestCompleterGetPutSides(t *testing.T) {
 	// Two completer calls reach the channel (get source and put target), each
 	// needs its own ls response.
 	ch := newMockChannel(
-		makeJSONDataMsg(&Response{OK: true, Entries: remoteEntries(
+		makeResponseMsg(&Response{OK: true, Entries: remoteEntries(
 			FileInfo{Name: "remote.txt"},
 		)}),
-		makeJSONDataMsg(&Response{OK: true, Entries: remoteEntries(
+		makeResponseMsg(&Response{OK: true, Entries: remoteEntries(
 			FileInfo{Name: "remote.txt"},
 		)}),
 	)
@@ -246,15 +245,15 @@ func TestCompleterGetPutSides(t *testing.T) {
 func TestEditorRemoteTabCompletion(t *testing.T) {
 	q := newQueuedMockChannel()
 	q.enqueue(
-		makeJSONDataMsg(&Response{OK: true, Entries: remoteEntries(
+		makeResponseMsg(&Response{OK: true, Entries: remoteEntries(
 			FileInfo{Name: "src", IsDir: true},
 			FileInfo{Name: "src.tar.gz"},
 		)}),
-		makeJSONDataMsg(&Response{OK: true, Entries: remoteEntries(
+		makeResponseMsg(&Response{OK: true, Entries: remoteEntries(
 			FileInfo{Name: "src", IsDir: true},
 			FileInfo{Name: "src.tar.gz"},
 		)}),
-		makeJSONDataMsg(&Response{OK: true, Entries: remoteEntries(
+		makeResponseMsg(&Response{OK: true, Entries: remoteEntries(
 			FileInfo{Name: "main.go"},
 			FileInfo{Name: "util.go"},
 		)}),
@@ -286,7 +285,7 @@ func TestEditorRemoteTabCompletion(t *testing.T) {
 	}
 	for i, want := range []string{"/remote", "/remote", "/remote/src"} {
 		var got Request
-		if err := json.Unmarshal(writes[i], &got); err != nil {
+		if err := decodeRequestFrame(writes[i], &got); err != nil {
 			t.Fatalf("unmarshal request %d: %v", i, err)
 		}
 		if got.Cmd != "ls" || got.Path != want {

--- a/sftp/protocol.go
+++ b/sftp/protocol.go
@@ -1,16 +1,20 @@
 package sftp
 
 import (
-	"bytes"
-	"encoding/json"
+	"encoding/binary"
 	"fmt"
-	"io"
+	"sync"
 
 	ssh3 "github.com/h4sh5/sshoq"
 	ssh3Messages "github.com/h4sh5/sshoq/message"
 )
 
-const ChunkSize = 32 * 1024
+// ChunkSize is the size of the data chunks transfers are pipelined in. The
+// larger the chunk, the fewer requests, protocol frames and per-chunk syscalls
+// a transfer needs for a given amount of data. 128 KiB keeps the per-byte
+// overhead low while bounding the in-flight memory of the transfer window
+// (TransferWindow × ChunkSize per direction).
+const ChunkSize = 128 * 1024
 
 // TransferWindow is the number of in-flight read/write requests the pipelined
 // transfer loops keep queued. On links with non-trivial round-trip time this
@@ -19,45 +23,488 @@ const ChunkSize = 32 * 1024
 // very high-latency links can benefit from larger values.
 const TransferWindow = 8
 
+// maxFrameSize caps the size of a single protocol frame. The protocol is
+// length-prefixed so a corrupt or hostile stream could otherwise claim a
+// 4 GiB frame and force a matching allocation; 64 MiB comfortably covers the
+// largest legitimate frame (a listing of a very large directory) plus a data
+// chunk.
+const maxFrameSize = 64 << 20
+
+// maxEntries caps the number of FileInfo entries a single ls response may
+// carry. Every entry costs at least 37 bytes on the wire, so this bound is
+// well within maxFrameSize; it exists so a corrupt length field cannot force a
+// huge allocation before the frame contents are validated.
+const maxEntries = 1 << 20
+
 type Request struct {
-	ID     uint64 `json:"id"`
-	Cmd    string `json:"cmd"`
-	Path   string `json:"path,omitempty"`
-	Offset int64  `json:"offset,omitempty"`
-	Limit  int    `json:"limit,omitempty"`
-	Data   []byte `json:"data,omitempty"`
+	ID     uint64
+	Cmd    string
+	Path   string
+	Offset int64
+	Limit  int
+	Data   []byte
 }
 
 type FileInfo struct {
-	Name       string `json:"name"`
-	Size       int64  `json:"size"`
-	Mode       uint32 `json:"mode"`
-	IsDir      bool   `json:"is_dir"`
-	IsSymlink  bool   `json:"is_symlink,omitempty"`
-	LinkTarget string `json:"link_target,omitempty"`
-	ModTime    int64  `json:"mod_time"`
-	UID        uint32 `json:"uid"`
-	GID        uint32 `json:"gid"`
-	UserName   string `json:"user_name,omitempty"`
-	GroupName  string `json:"group_name,omitempty"`
+	Name       string
+	Size       int64
+	Mode       uint32
+	IsDir      bool
+	IsSymlink  bool
+	LinkTarget string
+	ModTime    int64
+	UID        uint32
+	GID        uint32
+	UserName   string
+	GroupName  string
 }
 
 type Response struct {
-	ID      uint64     `json:"id"`
-	OK      bool       `json:"ok"`
-	Error   string     `json:"error,omitempty"`
-	Path    string     `json:"path,omitempty"`
-	Entries []FileInfo `json:"entries,omitempty"`
-	Data    []byte     `json:"data,omitempty"`
-	Info    *FileInfo  `json:"info,omitempty"`
+	ID      uint64
+	OK      bool
+	Error   string
+	Path    string
+	Entries []FileInfo
+	Data    []byte
+	Info    *FileInfo
 }
 
-func SendRequest(ch ssh3.Channel, req *Request) error {
-	data, err := json.Marshal(req)
+// The SFTP channel carries a compact binary protocol instead of JSON. Every
+// logical message is one frame:
+//
+//	[4 bytes] frame length N (big-endian), the number of bytes that follow
+//	[N bytes] message payload
+//
+// The length prefix makes frames self-delimiting, so a frame split across
+// several channel data messages (channelImpl.WriteData fragments anything
+// larger than the negotiated maximum packet size) is reassembled by the
+// receiver without parsing. Request and response payloads use fixed-width
+// big-endian integers and length-prefixed strings; file data is carried as
+// raw bytes. Compared with the previous JSON encoding this removes the base64
+// expansion of data chunks (a 33% wire overhead on transfers), the JSON field
+// names and escaping, and the marshal/unmarshal CPU cost on every chunk.
+//
+// Request payload:
+//
+//	[1 byte]  command code
+//	[8 bytes] request ID
+//	[2 bytes] path length, then the path bytes
+//	[8 bytes] offset (int64)
+//	[4 bytes] limit (uint32)
+//	[4 bytes] data length, then the raw data bytes
+//
+// Response payload:
+//
+//	[8 bytes] request ID
+//	[1 byte]  ok (0/1)
+//	[2 bytes] error length, then the error bytes
+//	[2 bytes] path length, then the path bytes
+//	[4 bytes] entry count, then that many FileInfo records
+//	[4 bytes] data length, then the raw data bytes
+//	[1 byte]  has info (0/1), then a FileInfo record when set
+//
+// FileInfo record:
+//
+//	[2 bytes] name length, then the name
+//	[8 bytes] size (int64)
+//	[4 bytes] mode (uint32)
+//	[1 byte]  flags: bit 0 = directory, bit 1 = symlink
+//	[2 bytes] link target length, then the link target
+//	[8 bytes] modification time (int64, Unix seconds)
+//	[4 bytes] uid
+//	[4 bytes] gid
+//	[2 bytes] user name length, then the user name
+//	[2 bytes] group name length, then the group name
+
+// Command codes for the binary request format.
+const (
+	cmdPwd byte = iota + 1
+	cmdCd
+	cmdLs
+	cmdStat
+	cmdGet
+	cmdPut
+	cmdMkdir
+	cmdRm
+	cmdRmdir
+)
+
+func cmdCode(cmd string) byte {
+	switch cmd {
+	case "pwd":
+		return cmdPwd
+	case "cd":
+		return cmdCd
+	case "ls":
+		return cmdLs
+	case "stat":
+		return cmdStat
+	case "get":
+		return cmdGet
+	case "put":
+		return cmdPut
+	case "mkdir":
+		return cmdMkdir
+	case "rm":
+		return cmdRm
+	case "rmdir":
+		return cmdRmdir
+	}
+	return 0
+}
+
+func cmdName(code byte) string {
+	switch code {
+	case cmdPwd:
+		return "pwd"
+	case cmdCd:
+		return "cd"
+	case cmdLs:
+		return "ls"
+	case cmdStat:
+		return "stat"
+	case cmdGet:
+		return "get"
+	case cmdPut:
+		return "put"
+	case cmdMkdir:
+		return "mkdir"
+	case cmdRm:
+		return "rm"
+	case cmdRmdir:
+		return "rmdir"
+	}
+	return ""
+}
+
+// --- Frame encoding ---
+
+func appendU8(b []byte, v byte) []byte    { return append(b, v) }
+func appendU16(b []byte, v uint16) []byte { return binary.BigEndian.AppendUint16(b, v) }
+func appendU32(b []byte, v uint32) []byte { return binary.BigEndian.AppendUint32(b, v) }
+func appendU64(b []byte, v uint64) []byte { return binary.BigEndian.AppendUint64(b, v) }
+func appendI64(b []byte, v int64) []byte  { return binary.BigEndian.AppendUint64(b, uint64(v)) }
+func appendStr(b []byte, s string) []byte {
+	b = appendU16(b, uint16(len(s)))
+	return append(b, s...)
+}
+func appendBytes(b []byte, p []byte) []byte {
+	b = appendU32(b, uint32(len(p)))
+	return append(b, p...)
+}
+
+// EncodeRequest serializes req into a complete binary frame: a 4-byte
+// big-endian length prefix followed by the payload.
+func EncodeRequest(req *Request) []byte {
+	size := 4 + 1 + 8 + 2 + len(req.Path) + 8 + 4 + 4 + len(req.Data)
+	buf := make([]byte, 4, size)
+	return encodeRequestFrameInto(buf, req)
+}
+
+func encodeRequestFrameInto(buf []byte, req *Request) []byte {
+	buf = appendU8(buf, cmdCode(req.Cmd))
+	buf = appendU64(buf, req.ID)
+	buf = appendStr(buf, req.Path)
+	buf = appendI64(buf, req.Offset)
+	buf = appendU32(buf, uint32(req.Limit))
+	buf = appendBytes(buf, req.Data)
+	binary.BigEndian.PutUint32(buf, uint32(len(buf)-4))
+	return buf
+}
+
+// EncodeResponse serializes resp into a complete binary frame: a 4-byte
+// big-endian length prefix followed by the payload.
+func EncodeResponse(resp *Response) []byte {
+	buf := make([]byte, 4, responseFrameSize(resp))
+	return encodeResponseFrameInto(buf, resp)
+}
+
+func responseFrameSize(resp *Response) int {
+	size := 4 + 8 + 1 + 2 + len(resp.Error) + 2 + len(resp.Path) + 4 + 4 + len(resp.Data) + 1
+	for i := range resp.Entries {
+		size += fileInfoFrameSize(&resp.Entries[i])
+	}
+	if resp.Info != nil {
+		size += fileInfoFrameSize(resp.Info)
+	}
+	return size
+}
+
+func fileInfoFrameSize(e *FileInfo) int {
+	return 2 + len(e.Name) + 8 + 4 + 1 + 2 + len(e.LinkTarget) + 8 + 4 + 4 + 2 + len(e.UserName) + 2 + len(e.GroupName)
+}
+
+func encodeResponseFrameInto(buf []byte, resp *Response) []byte {
+	buf = appendU64(buf, resp.ID)
+	if resp.OK {
+		buf = appendU8(buf, 1)
+	} else {
+		buf = appendU8(buf, 0)
+	}
+	buf = appendStr(buf, resp.Error)
+	buf = appendStr(buf, resp.Path)
+	buf = appendU32(buf, uint32(len(resp.Entries)))
+	for i := range resp.Entries {
+		buf = encodeFileInfoInto(buf, &resp.Entries[i])
+	}
+	buf = appendBytes(buf, resp.Data)
+	if resp.Info != nil {
+		buf = appendU8(buf, 1)
+		buf = encodeFileInfoInto(buf, resp.Info)
+	} else {
+		buf = appendU8(buf, 0)
+	}
+	binary.BigEndian.PutUint32(buf, uint32(len(buf)-4))
+	return buf
+}
+
+func encodeFileInfoInto(buf []byte, e *FileInfo) []byte {
+	buf = appendStr(buf, e.Name)
+	buf = appendI64(buf, e.Size)
+	buf = appendU32(buf, e.Mode)
+	var flags byte
+	if e.IsDir {
+		flags |= 1
+	}
+	if e.IsSymlink {
+		flags |= 2
+	}
+	buf = appendU8(buf, flags)
+	buf = appendStr(buf, e.LinkTarget)
+	buf = appendI64(buf, e.ModTime)
+	buf = appendU32(buf, e.UID)
+	buf = appendU32(buf, e.GID)
+	buf = appendStr(buf, e.UserName)
+	buf = appendStr(buf, e.GroupName)
+	return buf
+}
+
+// --- Frame decoding ---
+
+// frameCursor walks a frame payload. String fields are copied out of the
+// frame; byte slices (the Data fields) alias the frame, which is safe because
+// a fresh frame is allocated for every received message and the decoded data
+// is consumed before the next message is read.
+type frameCursor struct {
+	b   []byte
+	pos int
+}
+
+func (c *frameCursor) take(n int) ([]byte, error) {
+	if n < 0 || c.pos+n > len(c.b) {
+		return nil, fmt.Errorf("sftp: truncated frame")
+	}
+	s := c.b[c.pos : c.pos+n]
+	c.pos += n
+	return s, nil
+}
+
+func (c *frameCursor) u8() (byte, error) {
+	s, err := c.take(1)
+	if err != nil {
+		return 0, err
+	}
+	return s[0], nil
+}
+
+func (c *frameCursor) u16() (uint16, error) {
+	s, err := c.take(2)
+	if err != nil {
+		return 0, err
+	}
+	return binary.BigEndian.Uint16(s), nil
+}
+
+func (c *frameCursor) u32() (uint32, error) {
+	s, err := c.take(4)
+	if err != nil {
+		return 0, err
+	}
+	return binary.BigEndian.Uint32(s), nil
+}
+
+func (c *frameCursor) u64() (uint64, error) {
+	s, err := c.take(8)
+	if err != nil {
+		return 0, err
+	}
+	return binary.BigEndian.Uint64(s), nil
+}
+
+func (c *frameCursor) i64() (int64, error) {
+	v, err := c.u64()
+	return int64(v), err
+}
+
+func (c *frameCursor) str() (string, error) {
+	n, err := c.u16()
+	if err != nil {
+		return "", err
+	}
+	s, err := c.take(int(n))
+	if err != nil {
+		return "", err
+	}
+	return string(s), nil
+}
+
+// bytes returns the next length-prefixed byte slice, aliasing the frame.
+func (c *frameCursor) bytes() ([]byte, error) {
+	n, err := c.u32()
+	if err != nil {
+		return nil, err
+	}
+	return c.take(int(n))
+}
+
+// DecodeRequest deserializes a request frame into req. The Data field aliases
+// payload and stays valid for the lifetime of payload.
+func DecodeRequest(payload []byte, req *Request) error {
+	c := &frameCursor{b: payload}
+	code, err := c.u8()
 	if err != nil {
 		return err
 	}
-	_, err = ch.WriteData(data, ssh3Messages.SSH_EXTENDED_DATA_NONE)
+	if req.ID, err = c.u64(); err != nil {
+		return err
+	}
+	if req.Path, err = c.str(); err != nil {
+		return err
+	}
+	if req.Offset, err = c.i64(); err != nil {
+		return err
+	}
+	limit, err := c.u32()
+	if err != nil {
+		return err
+	}
+	req.Limit = int(limit)
+	if req.Data, err = c.bytes(); err != nil {
+		return err
+	}
+	req.Cmd = cmdName(code)
+	return nil
+}
+
+// DecodeResponse deserializes a response frame into resp. The Data field
+// aliases payload and stays valid for the lifetime of payload.
+func DecodeResponse(payload []byte, resp *Response) error {
+	c := &frameCursor{b: payload}
+	var err error
+	if resp.ID, err = c.u64(); err != nil {
+		return err
+	}
+	ok, err := c.u8()
+	if err != nil {
+		return err
+	}
+	resp.OK = ok != 0
+	if resp.Error, err = c.str(); err != nil {
+		return err
+	}
+	if resp.Path, err = c.str(); err != nil {
+		return err
+	}
+	count, err := c.u32()
+	if err != nil {
+		return err
+	}
+	if count > maxEntries {
+		return fmt.Errorf("sftp: too many entries: %d", count)
+	}
+	resp.Entries = nil
+	if count > 0 {
+		resp.Entries = make([]FileInfo, 0, count)
+		for i := 0; i < int(count); i++ {
+			var e FileInfo
+			if err := decodeFileInfo(c, &e); err != nil {
+				return err
+			}
+			resp.Entries = append(resp.Entries, e)
+		}
+	}
+	if resp.Data, err = c.bytes(); err != nil {
+		return err
+	}
+	hasInfo, err := c.u8()
+	if err != nil {
+		return err
+	}
+	resp.Info = nil
+	if hasInfo != 0 {
+		resp.Info = &FileInfo{}
+		if err := decodeFileInfo(c, resp.Info); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func decodeFileInfo(c *frameCursor, e *FileInfo) error {
+	var err error
+	if e.Name, err = c.str(); err != nil {
+		return err
+	}
+	if e.Size, err = c.i64(); err != nil {
+		return err
+	}
+	if e.Mode, err = c.u32(); err != nil {
+		return err
+	}
+	flags, err := c.u8()
+	if err != nil {
+		return err
+	}
+	e.IsDir = flags&1 != 0
+	e.IsSymlink = flags&2 != 0
+	if e.LinkTarget, err = c.str(); err != nil {
+		return err
+	}
+	if e.ModTime, err = c.i64(); err != nil {
+		return err
+	}
+	if e.UID, err = c.u32(); err != nil {
+		return err
+	}
+	if e.GID, err = c.u32(); err != nil {
+		return err
+	}
+	if e.UserName, err = c.str(); err != nil {
+		return err
+	}
+	if e.GroupName, err = c.str(); err != nil {
+		return err
+	}
+	return nil
+}
+
+// --- Channel transport ---
+
+// framePoolCap is the capacity of pooled frame buffers. Frames carrying a
+// data chunk dominate transfer traffic and fit in a chunk-sized buffer plus
+// the fixed protocol fields. Larger frames (a listing of a huge directory)
+// grow past this and are simply not pooled.
+const framePoolCap = 4 + ChunkSize + 128
+
+// framePool recycles the send-side frame buffers. WriteData consumes the
+// frame synchronously (copying it into channel messages), so a buffer can be
+// returned to the pool as soon as the write returns. This removes a per-chunk
+// allocation from both the client's pipelined transfers and the server's
+// response loop.
+var framePool = sync.Pool{
+	New: func() interface{} {
+		return make([]byte, 4, framePoolCap)
+	},
+}
+
+// SendRequest writes one request frame to the channel. Request frames are
+// self-delimiting (4-byte length prefix), so a frame fragmented across
+// several channel data messages is reassembled by the receiver.
+func SendRequest(ch ssh3.Channel, req *Request) error {
+	buf := framePool.Get().([]byte)
+	buf = encodeRequestFrameInto(buf, req)
+	_, err := ch.WriteData(buf, ssh3Messages.SSH_EXTENDED_DATA_NONE)
+	framePool.Put(buf[:4])
 	return err
 }
 
@@ -67,13 +514,14 @@ type sftpMessageChannel interface {
 	NextMessage() (ssh3Messages.Message, error)
 }
 
-// receiveJSON reads one complete logical SFTP message from the channel and
-// returns its raw JSON payload. Channel writes split payloads larger than the
-// negotiated maximum packet size across several DataOrExtendedDataMessage
-// messages (see channelImpl.WriteData), so the payloads of consecutive data
-// messages are accumulated until they form a single complete JSON document.
-// Non-data messages are skipped, mirroring the previous request loop.
-func receiveJSON(ch sftpMessageChannel) ([]byte, error) {
+// receiveFrame reads one complete logical SFTP frame from the channel and
+// returns its payload (the bytes after the length prefix). Channel writes
+// split payloads larger than the negotiated maximum packet size across
+// several DataOrExtendedDataMessage messages (see channelImpl.WriteData), so
+// the payloads of consecutive data messages are accumulated until the length
+// prefix says the frame is complete. Non-data messages are skipped, mirroring
+// the previous request loop.
+func receiveFrame(ch sftpMessageChannel) ([]byte, error) {
 	var payload []byte
 	for {
 		msg, err := ch.NextMessage()
@@ -85,50 +533,36 @@ func receiveJSON(ch sftpMessageChannel) ([]byte, error) {
 			continue
 		}
 		payload = append(payload, dataMsg.Data...)
-		complete, err := isCompleteJSON(payload)
-		if err != nil {
-			return nil, err
+		if len(payload) < 4 {
+			continue
 		}
-		if complete {
-			return payload, nil
+		total := 4 + int(binary.BigEndian.Uint32(payload[:4]))
+		if total > maxFrameSize {
+			return nil, fmt.Errorf("sftp: frame too large: %d bytes", total)
+		}
+		// Grow to exactly total once, so a frame split across several channel
+		// data messages is not reallocated and copied on every fragment.
+		if len(payload) < total && cap(payload) < total {
+			grown := make([]byte, len(payload), total)
+			copy(grown, payload)
+			payload = grown
+		}
+		if len(payload) >= total {
+			return payload[4:total], nil
 		}
 	}
 }
 
-// isCompleteJSON reports whether payload is exactly one complete JSON document.
-// A payload that ends in the middle of a document (a truncated prefix of a
-// message that is still arriving across channel data messages) is reported as
-// incomplete, not as an error.
-func isCompleteJSON(payload []byte) (bool, error) {
-	dec := json.NewDecoder(bytes.NewReader(payload))
-	var v interface{}
-	if err := dec.Decode(&v); err != nil {
-		if err == io.ErrUnexpectedEOF {
-			return false, nil
-		}
-		return false, err
-	}
-	// A second decode must hit EOF: the payload must be exactly one value,
-	// with no trailing data.
-	if err := dec.Decode(&v); err != nil {
-		if err == io.EOF {
-			return true, nil
-		}
-		if err == io.ErrUnexpectedEOF {
-			return false, nil
-		}
-		return false, err
-	}
-	return false, fmt.Errorf("multiple JSON values in one sftp message")
-}
-
+// ReceiveResponse reads the next response frame from the channel and decodes
+// it. The returned response's Data field aliases the frame payload; the
+// payload is not reused by subsequent calls, so the data stays valid.
 func ReceiveResponse(ch ssh3.Channel) (*Response, error) {
-	payload, err := receiveJSON(ch)
+	payload, err := receiveFrame(ch)
 	if err != nil {
 		return nil, err
 	}
 	resp := &Response{}
-	if err := json.Unmarshal(payload, resp); err != nil {
+	if err := DecodeResponse(payload, resp); err != nil {
 		return nil, err
 	}
 	return resp, nil

--- a/sftp/quoting_test.go
+++ b/sftp/quoting_test.go
@@ -1,7 +1,6 @@
 package sftp
 
 import (
-	"encoding/json"
 	"errors"
 	"os"
 	"path/filepath"
@@ -497,7 +496,7 @@ func TestMakeargvErrorType(t *testing.T) {
 // metacharacter is not treated as a glob: ls foo\* lists the literal path
 // "foo*" (after makeargv, the escaped star reaches doLs as "foo\*").
 func TestClientDoLsEscapedLiteralGlob(t *testing.T) {
-	ch := newMockChannel(makeJSONDataMsg(&Response{
+	ch := newMockChannel(makeResponseMsg(&Response{
 		OK:      true,
 		Entries: lsEntries("inside"),
 	}))
@@ -509,7 +508,7 @@ func TestClientDoLsEscapedLiteralGlob(t *testing.T) {
 	if len(ch.Writes) != 1 {
 		t.Fatalf("expected 1 request, got %d", len(ch.Writes))
 	}
-	if err := json.Unmarshal(ch.Writes[0], &got); err != nil {
+	if err := decodeRequestFrame(ch.Writes[0], &got); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
 	if got.Cmd != "ls" || got.Path != "/remote/foo*" {
@@ -521,7 +520,7 @@ func TestClientDoLsEscapedLiteralGlob(t *testing.T) {
 // directory is un-escaped before the ls request: ls 'sub\ dir'/*.txt lists
 // /remote/sub dir and matches entries against *.txt.
 func TestClientDoLsEscapedSpaceInDir(t *testing.T) {
-	ch := newMockChannel(makeJSONDataMsg(&Response{
+	ch := newMockChannel(makeResponseMsg(&Response{
 		OK:      true,
 		Entries: lsEntries("a.txt", "b.txt", "c.md"),
 	}))
@@ -533,7 +532,7 @@ func TestClientDoLsEscapedSpaceInDir(t *testing.T) {
 	if len(ch.Writes) != 1 {
 		t.Fatalf("expected 1 request, got %d", len(ch.Writes))
 	}
-	if err := json.Unmarshal(ch.Writes[0], &got); err != nil {
+	if err := decodeRequestFrame(ch.Writes[0], &got); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
 	if got.Cmd != "ls" || got.Path != "/remote/sub dir" {
@@ -545,7 +544,7 @@ func TestClientDoLsEscapedSpaceInDir(t *testing.T) {
 // escaped to a literal: ls 'test*' must not glob, so the request goes to the
 // literal path /remote/test*.
 func TestClientDoLsQuotedWildcard(t *testing.T) {
-	ch := newMockChannel(makeJSONDataMsg(&Response{
+	ch := newMockChannel(makeResponseMsg(&Response{
 		OK:      true,
 		Entries: lsEntries("inside"),
 	}))
@@ -557,7 +556,7 @@ func TestClientDoLsQuotedWildcard(t *testing.T) {
 	if len(ch.Writes) != 1 {
 		t.Fatalf("expected 1 request, got %d", len(ch.Writes))
 	}
-	if err := json.Unmarshal(ch.Writes[0], &got); err != nil {
+	if err := decodeRequestFrame(ch.Writes[0], &got); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
 	if got.Cmd != "ls" || got.Path != "/remote/test*" {
@@ -570,9 +569,9 @@ func TestClientDoLsQuotedWildcard(t *testing.T) {
 func TestClientDoGetQuotedPath(t *testing.T) {
 	localDir := t.TempDir()
 	ch := newMockChannel(
-		makeJSONDataMsg(&Response{OK: true, Info: &FileInfo{Name: "Test File.txt", Size: 5}}),
-		makeJSONDataMsg(&Response{OK: true, Data: []byte("hello")}),
-		makeJSONDataMsg(&Response{OK: true, Data: []byte{}}),
+		makeResponseMsg(&Response{OK: true, Info: &FileInfo{Name: "Test File.txt", Size: 5}}),
+		makeResponseMsg(&Response{OK: true, Data: []byte("hello")}),
+		makeResponseMsg(&Response{OK: true, Data: []byte{}}),
 	)
 	// parts simulate the output of makeargv("get 'Downloads/Test File.txt'").
 	if err := doGet(ch, localDir, "/remote", []string{"get", "Downloads/Test File.txt"}, true, nil); err != nil {
@@ -582,7 +581,7 @@ func TestClientDoGetQuotedPath(t *testing.T) {
 	if len(ch.Writes) != 3 {
 		t.Fatalf("expected 3 requests, got %d", len(ch.Writes))
 	}
-	if err := json.Unmarshal(ch.Writes[0], &got); err != nil {
+	if err := decodeRequestFrame(ch.Writes[0], &got); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
 	if got.Cmd != "stat" || got.Path != "/remote/Downloads/Test File.txt" {
@@ -604,9 +603,9 @@ func TestClientDoGetQuotedPath(t *testing.T) {
 func TestClientDoGetEscapedGlobMetachar(t *testing.T) {
 	localDir := t.TempDir()
 	ch := newMockChannel(
-		makeJSONDataMsg(&Response{OK: true, Info: &FileInfo{Name: "foo*.txt", Size: 5}}),
-		makeJSONDataMsg(&Response{OK: true, Data: []byte("hello")}),
-		makeJSONDataMsg(&Response{OK: true, Data: []byte{}}),
+		makeResponseMsg(&Response{OK: true, Info: &FileInfo{Name: "foo*.txt", Size: 5}}),
+		makeResponseMsg(&Response{OK: true, Data: []byte("hello")}),
+		makeResponseMsg(&Response{OK: true, Data: []byte{}}),
 	)
 	// parts simulate the output of makeargv("get 'foo*.txt'").
 	if err := doGet(ch, localDir, "/remote", []string{"get", `foo\*.txt`}, true, nil); err != nil {
@@ -616,7 +615,7 @@ func TestClientDoGetEscapedGlobMetachar(t *testing.T) {
 	if len(ch.Writes) != 3 {
 		t.Fatalf("expected 3 requests, got %d", len(ch.Writes))
 	}
-	if err := json.Unmarshal(ch.Writes[0], &got); err != nil {
+	if err := decodeRequestFrame(ch.Writes[0], &got); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
 	if got.Cmd != "stat" || got.Path != "/remote/foo*.txt" {
@@ -635,7 +634,7 @@ func TestClientDoGetEscapedGlobMetachar(t *testing.T) {
 // word: the candidate is re-quoted (opening and closing quote) and the
 // replacement starts at the opening quote.
 func TestCompleterQuotedWord(t *testing.T) {
-	ch := newMockChannel(makeJSONDataMsg(&Response{OK: true, Entries: remoteEntries(
+	ch := newMockChannel(makeResponseMsg(&Response{OK: true, Entries: remoteEntries(
 		FileInfo{Name: "remote.txt"},
 	)}))
 	localDir, remoteDir := "/local", "/remote"
@@ -654,7 +653,7 @@ func TestCompleterQuotedWord(t *testing.T) {
 // containing a space: the directory is resolved from the parsed word and the
 // candidate is wrapped in quotes.
 func TestCompleterQuotedWordWithSpace(t *testing.T) {
-	ch := newMockChannel(makeJSONDataMsg(&Response{OK: true, Entries: remoteEntries(
+	ch := newMockChannel(makeResponseMsg(&Response{OK: true, Entries: remoteEntries(
 		FileInfo{Name: "foobar.txt"},
 	)}))
 	localDir, remoteDir := "/local", "/remote"
@@ -668,7 +667,7 @@ func TestCompleterQuotedWordWithSpace(t *testing.T) {
 		t.Errorf("candidates = %v, want ['my dir/foobar.txt']", cands)
 	}
 	var got Request
-	if err := json.Unmarshal(ch.Writes[0], &got); err != nil {
+	if err := decodeRequestFrame(ch.Writes[0], &got); err != nil {
 		t.Fatalf("unmarshal request: %v", err)
 	}
 	if got.Cmd != "ls" || got.Path != "/remote/my dir" {
@@ -750,7 +749,7 @@ func TestParseTransferArgsQuoted(t *testing.T) {
 // TestCompleterUTF8Spans verifies that completion start offsets are rune
 // indices even when the prefix contains multibyte characters.
 func TestCompleterUTF8Spans(t *testing.T) {
-	ch := newMockChannel(makeJSONDataMsg(&Response{OK: true, Entries: remoteEntries(
+	ch := newMockChannel(makeResponseMsg(&Response{OK: true, Entries: remoteEntries(
 		FileInfo{Name: "café.txt"},
 	)}))
 	localDir, remoteDir := "/local", "/remote"
@@ -766,7 +765,7 @@ func TestCompleterUTF8Spans(t *testing.T) {
 		t.Errorf("candidates = %v, want [docé/café.txt]", cands)
 	}
 	var got Request
-	if err := json.Unmarshal(ch.Writes[0], &got); err != nil {
+	if err := decodeRequestFrame(ch.Writes[0], &got); err != nil {
 		t.Fatalf("unmarshal request: %v", err)
 	}
 	if got.Path != "/remote/docé" {

--- a/sftp/scp_test.go
+++ b/sftp/scp_test.go
@@ -1,7 +1,6 @@
 package sftp
 
 import (
-	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
@@ -16,7 +15,7 @@ func TestScpUploadFileToTrailingSlashTarget(t *testing.T) {
 	os.WriteFile(localPath, []byte("hello"), 0644)
 
 	ch := newMockChannel(
-		makeJSONDataMsg(&Response{ID: 1, OK: true}),
+		makeResponseMsg(&Response{ID: 1, OK: true}),
 	)
 
 	if err := scpUpload(ch, false, localPath, "/tmp/", nil); err != nil {
@@ -27,7 +26,7 @@ func TestScpUploadFileToTrailingSlashTarget(t *testing.T) {
 		t.Fatalf("expected 1 request, got %d", len(ch.Writes))
 	}
 	var got Request
-	if err := json.Unmarshal(ch.Writes[0], &got); err != nil {
+	if err := decodeRequestFrame(ch.Writes[0], &got); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
 	if got.Cmd != "put" || got.Path != "/tmp/local.txt" {
@@ -44,8 +43,8 @@ func TestScpUploadFileToExistingRemoteDir(t *testing.T) {
 	os.WriteFile(localPath, []byte("hello"), 0644)
 
 	ch := newMockChannel(
-		makeJSONDataMsg(&Response{ID: 1, OK: true, Info: &FileInfo{Name: "remotedir", IsDir: true}}),
-		makeJSONDataMsg(&Response{ID: 2, OK: true}),
+		makeResponseMsg(&Response{ID: 1, OK: true, Info: &FileInfo{Name: "remotedir", IsDir: true}}),
+		makeResponseMsg(&Response{ID: 2, OK: true}),
 	)
 
 	if err := scpUpload(ch, false, localPath, "/tmp/remotedir", nil); err != nil {
@@ -56,10 +55,10 @@ func TestScpUploadFileToExistingRemoteDir(t *testing.T) {
 		t.Fatalf("expected 2 requests (stat + put), got %d", len(ch.Writes))
 	}
 	var statReq, putReq Request
-	if err := json.Unmarshal(ch.Writes[0], &statReq); err != nil {
+	if err := decodeRequestFrame(ch.Writes[0], &statReq); err != nil {
 		t.Fatalf("unmarshal stat: %v", err)
 	}
-	if err := json.Unmarshal(ch.Writes[1], &putReq); err != nil {
+	if err := decodeRequestFrame(ch.Writes[1], &putReq); err != nil {
 		t.Fatalf("unmarshal put: %v", err)
 	}
 	if statReq.Cmd != "stat" || statReq.Path != "/tmp/remotedir" {
@@ -79,8 +78,8 @@ func TestScpUploadFileToNewRemoteName(t *testing.T) {
 	os.WriteFile(localPath, []byte("hello"), 0644)
 
 	ch := newMockChannel(
-		makeJSONDataMsg(&Response{ID: 1, OK: false, Error: "no such file"}),
-		makeJSONDataMsg(&Response{ID: 2, OK: true}),
+		makeResponseMsg(&Response{ID: 1, OK: false, Error: "no such file"}),
+		makeResponseMsg(&Response{ID: 2, OK: true}),
 	)
 
 	if err := scpUpload(ch, false, localPath, "/tmp/remotefile", nil); err != nil {
@@ -91,7 +90,7 @@ func TestScpUploadFileToNewRemoteName(t *testing.T) {
 		t.Fatalf("expected 2 requests (stat + put), got %d", len(ch.Writes))
 	}
 	var putReq Request
-	if err := json.Unmarshal(ch.Writes[1], &putReq); err != nil {
+	if err := decodeRequestFrame(ch.Writes[1], &putReq); err != nil {
 		t.Fatalf("unmarshal put: %v", err)
 	}
 	if putReq.Cmd != "put" || putReq.Path != "/tmp/remotefile" {
@@ -139,14 +138,14 @@ func TestScpUploadRecursiveDirectoryToTrailingSlashTarget(t *testing.T) {
 	//   upload file "b.txt":
 	//     put("/tmp/localfolder/sub/b.txt") -> ok
 	ch := newMockChannel(
-		makeJSONDataMsg(&Response{ID: 1, OK: false, Error: "no such file"}),
-		makeJSONDataMsg(&Response{ID: 2, OK: true, Info: &FileInfo{Name: "tmp", IsDir: true}}),
-		makeJSONDataMsg(&Response{ID: 3, OK: true}),
-		makeJSONDataMsg(&Response{ID: 4, OK: true}),
-		makeJSONDataMsg(&Response{ID: 5, OK: false, Error: "no such file"}),
-		makeJSONDataMsg(&Response{ID: 6, OK: true, Info: &FileInfo{Name: "localfolder", IsDir: true}}),
-		makeJSONDataMsg(&Response{ID: 7, OK: true}),
-		makeJSONDataMsg(&Response{ID: 8, OK: true}),
+		makeResponseMsg(&Response{ID: 1, OK: false, Error: "no such file"}),
+		makeResponseMsg(&Response{ID: 2, OK: true, Info: &FileInfo{Name: "tmp", IsDir: true}}),
+		makeResponseMsg(&Response{ID: 3, OK: true}),
+		makeResponseMsg(&Response{ID: 4, OK: true}),
+		makeResponseMsg(&Response{ID: 5, OK: false, Error: "no such file"}),
+		makeResponseMsg(&Response{ID: 6, OK: true, Info: &FileInfo{Name: "localfolder", IsDir: true}}),
+		makeResponseMsg(&Response{ID: 7, OK: true}),
+		makeResponseMsg(&Response{ID: 8, OK: true}),
 	)
 
 	if err := scpUpload(ch, true, localDir, "/tmp/", nil); err != nil {
@@ -157,7 +156,7 @@ func TestScpUploadRecursiveDirectoryToTrailingSlashTarget(t *testing.T) {
 		t.Fatalf("expected 8 requests, got %d", len(ch.Writes))
 	}
 	var mkdirReq Request
-	if err := json.Unmarshal(ch.Writes[2], &mkdirReq); err != nil {
+	if err := decodeRequestFrame(ch.Writes[2], &mkdirReq); err != nil {
 		t.Fatalf("unmarshal mkdir: %v", err)
 	}
 	if mkdirReq.Cmd != "mkdir" || mkdirReq.Path != "/tmp/localfolder" {
@@ -174,9 +173,9 @@ func TestScpDownloadToExistingLocalDir(t *testing.T) {
 	content := []byte("hello from remote")
 
 	ch := newMockChannel(
-		makeJSONDataMsg(&Response{ID: 1, OK: true, Info: &FileInfo{Name: "remote.txt", Size: int64(len(content))}}),
-		makeJSONDataMsg(&Response{ID: 2, OK: true, Data: content}),
-		makeJSONDataMsg(&Response{ID: 3, OK: true, Data: []byte{}}),
+		makeResponseMsg(&Response{ID: 1, OK: true, Info: &FileInfo{Name: "remote.txt", Size: int64(len(content))}}),
+		makeResponseMsg(&Response{ID: 2, OK: true, Data: content}),
+		makeResponseMsg(&Response{ID: 3, OK: true, Data: []byte{}}),
 	)
 
 	if err := scpDownload(ch, false, "/etc/remote.txt", tmp, nil); err != nil {
@@ -195,7 +194,7 @@ func TestScpDownloadToExistingLocalDir(t *testing.T) {
 	if len(ch.Writes) != 3 {
 		t.Fatalf("expected 3 requests, got %d", len(ch.Writes))
 	}
-	if err := json.Unmarshal(ch.Writes[0], &statReq); err != nil {
+	if err := decodeRequestFrame(ch.Writes[0], &statReq); err != nil {
 		t.Fatalf("unmarshal stat: %v", err)
 	}
 	if statReq.Cmd != "stat" || statReq.Path != "/etc/remote.txt" {
@@ -211,9 +210,9 @@ func TestScpDownloadToTrailingSlashLocalTarget(t *testing.T) {
 	content := []byte("hello")
 
 	ch := newMockChannel(
-		makeJSONDataMsg(&Response{ID: 1, OK: true, Info: &FileInfo{Name: "remote.txt", Size: int64(len(content))}}),
-		makeJSONDataMsg(&Response{ID: 2, OK: true, Data: content}),
-		makeJSONDataMsg(&Response{ID: 3, OK: true, Data: []byte{}}),
+		makeResponseMsg(&Response{ID: 1, OK: true, Info: &FileInfo{Name: "remote.txt", Size: int64(len(content))}}),
+		makeResponseMsg(&Response{ID: 2, OK: true, Data: content}),
+		makeResponseMsg(&Response{ID: 3, OK: true, Data: []byte{}}),
 	)
 
 	target := filepath.Join(tmp, "out") + string(filepath.Separator)
@@ -238,9 +237,9 @@ func TestScpDownloadToNewLocalName(t *testing.T) {
 	content := []byte("hello")
 
 	ch := newMockChannel(
-		makeJSONDataMsg(&Response{ID: 1, OK: true, Info: &FileInfo{Name: "remote.txt", Size: int64(len(content))}}),
-		makeJSONDataMsg(&Response{ID: 2, OK: true, Data: content}),
-		makeJSONDataMsg(&Response{ID: 3, OK: true, Data: []byte{}}),
+		makeResponseMsg(&Response{ID: 1, OK: true, Info: &FileInfo{Name: "remote.txt", Size: int64(len(content))}}),
+		makeResponseMsg(&Response{ID: 2, OK: true, Data: content}),
+		makeResponseMsg(&Response{ID: 3, OK: true, Data: []byte{}}),
 	)
 
 	newName := filepath.Join(tmp, "newname")
@@ -265,10 +264,10 @@ func TestScpDownloadRecursiveToExistingLocalDir(t *testing.T) {
 	tmp := t.TempDir()
 
 	ch := newMockChannel(
-		makeJSONDataMsg(&Response{ID: 1, OK: true, Info: &FileInfo{Name: "nginx", IsDir: true}}),
-		makeJSONDataMsg(&Response{ID: 2, OK: true, Entries: []FileInfo{{Name: "nginx.conf", Size: 4, Mode: 0644}}}),
-		makeJSONDataMsg(&Response{ID: 3, OK: true, Data: []byte("conf")}),
-		makeJSONDataMsg(&Response{ID: 4, OK: true, Data: []byte{}}),
+		makeResponseMsg(&Response{ID: 1, OK: true, Info: &FileInfo{Name: "nginx", IsDir: true}}),
+		makeResponseMsg(&Response{ID: 2, OK: true, Entries: []FileInfo{{Name: "nginx.conf", Size: 4, Mode: 0644}}}),
+		makeResponseMsg(&Response{ID: 3, OK: true, Data: []byte("conf")}),
+		makeResponseMsg(&Response{ID: 4, OK: true, Data: []byte{}}),
 	)
 
 	if err := scpDownload(ch, true, "/etc/nginx", tmp, nil); err != nil {

--- a/sftp/server.go
+++ b/sftp/server.go
@@ -2,7 +2,6 @@ package sftp
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -73,7 +72,7 @@ func serveChannelInProcess(ctx context.Context, user *unix_util.User, channel sf
 	defer log.Info().Msgf("ending SFTP session for user %s", user.Username)
 
 	for {
-		payload, err := receiveJSON(channel)
+		payload, err := receiveFrame(channel)
 		if err != nil {
 			if err != io.EOF {
 				log.Error().Msgf("sftp channel error: %s", err)
@@ -82,7 +81,7 @@ func serveChannelInProcess(ctx context.Context, user *unix_util.User, channel sf
 		}
 
 		var req Request
-		if err := json.Unmarshal(payload, &req); err != nil {
+		if err := DecodeRequest(payload, &req); err != nil {
 			session.respond(&Response{Error: fmt.Sprintf("invalid request: %s", err)})
 			continue
 		}
@@ -210,11 +209,10 @@ func (s *ServerSession) groupName(gid uint32) string {
 }
 
 func (s *ServerSession) respond(resp *Response) error {
-	data, err := json.Marshal(resp)
-	if err != nil {
-		return err
-	}
-	_, err = s.channel.WriteData(data, ssh3Messages.SSH_EXTENDED_DATA_NONE)
+	buf := framePool.Get().([]byte)
+	buf = encodeResponseFrameInto(buf, resp)
+	_, err := s.channel.WriteData(buf, ssh3Messages.SSH_EXTENDED_DATA_NONE)
+	framePool.Put(buf[:4])
 	return err
 }
 

--- a/sftp/sftp_test.go
+++ b/sftp/sftp_test.go
@@ -2,7 +2,7 @@ package sftp
 
 import (
 	"bytes"
-	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -97,9 +97,25 @@ func makeDataMsg(data []byte) *ssh3Messages.DataOrExtendedDataMessage {
 	}
 }
 
-func makeJSONDataMsg(v interface{}) *ssh3Messages.DataOrExtendedDataMessage {
-	b, _ := json.Marshal(v)
-	return makeDataMsg(b)
+func makeResponseMsg(resp *Response) *ssh3Messages.DataOrExtendedDataMessage {
+	return makeDataMsg(EncodeResponse(resp))
+}
+
+// decodeRequestFrame and decodeResponseFrame decode a full frame as written
+// to the channel (4-byte length prefix followed by the payload) into a
+// Request/Response, mirroring the wire format.
+func decodeRequestFrame(data []byte, req *Request) error {
+	if len(data) < 4 {
+		return errors.New("short request frame")
+	}
+	return DecodeRequest(data[4:], req)
+}
+
+func decodeResponseFrame(data []byte, resp *Response) error {
+	if len(data) < 4 {
+		return errors.New("short response frame")
+	}
+	return DecodeResponse(data[4:], resp)
 }
 
 // newMockChannel creates a ssh3.MockChannel wired with pre-programmed messages.
@@ -119,7 +135,7 @@ func TestSendRequest(t *testing.T) {
 		t.Fatalf("expected 1 write, got %d", len(ch.Writes))
 	}
 	var got Request
-	if err := json.Unmarshal(ch.Writes[0], &got); err != nil {
+	if err := decodeRequestFrame(ch.Writes[0], &got); err != nil {
 		t.Fatalf("unmarshal error: %v", err)
 	}
 	if got.Cmd != "pwd" || got.ID != 1 {
@@ -129,7 +145,7 @@ func TestSendRequest(t *testing.T) {
 
 func TestReceiveResponse(t *testing.T) {
 	want := &Response{ID: 2, OK: true, Path: "/tmp"}
-	ch := newMockChannel(makeJSONDataMsg(want))
+	ch := newMockChannel(makeResponseMsg(want))
 	got, err := ReceiveResponse(ch)
 	if err != nil {
 		t.Fatalf("ReceiveResponse error: %v", err)
@@ -143,7 +159,7 @@ func TestReceiveResponse_SkipsNonDataMessages(t *testing.T) {
 	want := &Response{ID: 2, OK: true, Path: "/tmp"}
 	ch := newMockChannel(
 		&ssh3Messages.ChannelRequestMessage{},
-		makeJSONDataMsg(want),
+		makeResponseMsg(want),
 	)
 	got, err := ReceiveResponse(ch)
 	if err != nil {
@@ -160,7 +176,7 @@ func TestReceiveResponse_ChunkedMessage(t *testing.T) {
 	// MaxPacketSize minus framing bytes). ReceiveResponse must reassemble the
 	// chunks into a single JSON document instead of parsing a truncated one.
 	var entries []FileInfo
-	for i := 0; i < 500; i++ {
+	for i := 0; i < 800; i++ {
 		entries = append(entries, FileInfo{
 			Name:      fmt.Sprintf("file_%03d.txt", i),
 			Size:      4096,
@@ -174,10 +190,7 @@ func TestReceiveResponse_ChunkedMessage(t *testing.T) {
 		})
 	}
 	want := &Response{ID: 7, OK: true, Entries: entries}
-	raw, err := json.Marshal(want)
-	if err != nil {
-		t.Fatalf("marshal: %v", err)
-	}
+	raw := EncodeResponse(want)
 
 	msgs := splitIntoChannelMessages(raw)
 	if len(msgs) < 2 {
@@ -567,7 +580,7 @@ func TestServerRespond(t *testing.T) {
 		t.Fatalf("expected 1 write, got %d", len(ch.Writes))
 	}
 	var got Response
-	if err := json.Unmarshal(ch.Writes[0], &got); err != nil {
+	if err := decodeResponseFrame(ch.Writes[0], &got); err != nil {
 		t.Fatalf("unmarshal error: %v", err)
 	}
 	if got.ID != 42 || !got.OK {
@@ -664,10 +677,10 @@ func TestDownloadFile(t *testing.T) {
 	done := &Response{ID: 4, OK: true, Data: []byte{}}
 
 	ch := newMockChannel(
-		makeJSONDataMsg(statResp),
-		makeJSONDataMsg(chunk1),
-		makeJSONDataMsg(chunk2),
-		makeJSONDataMsg(done),
+		makeResponseMsg(statResp),
+		makeResponseMsg(chunk1),
+		makeResponseMsg(chunk2),
+		makeResponseMsg(done),
 	)
 
 	if err := downloadFile(ch, "remote.txt", localPath, true, nil); err != nil {
@@ -683,7 +696,7 @@ func TestDownloadFile(t *testing.T) {
 }
 
 func TestDownloadFile_StatFail(t *testing.T) {
-	ch := newMockChannel(makeJSONDataMsg(&Response{ID: 1, OK: false, Error: "no such file"}))
+	ch := newMockChannel(makeResponseMsg(&Response{ID: 1, OK: false, Error: "no such file"}))
 	err := downloadFile(ch, "missing", filepath.Join(t.TempDir(), "out"), true, nil)
 	if err == nil {
 		t.Fatal("expected error for stat failure")
@@ -694,7 +707,7 @@ func TestDownloadFile_StatFail(t *testing.T) {
 // reported without a path is enriched with the remote path on the client, so
 // errors like "too many levels of symbolic links" identify the file.
 func TestDownloadFile_ServerErrorIncludesPath(t *testing.T) {
-	ch := newMockChannel(makeJSONDataMsg(&Response{ID: 1, OK: false, Error: "too many levels of symbolic links"}))
+	ch := newMockChannel(makeResponseMsg(&Response{ID: 1, OK: false, Error: "too many levels of symbolic links"}))
 	err := downloadFile(ch, "loop/file.txt", filepath.Join(t.TempDir(), "out"), true, nil)
 	if err == nil {
 		t.Fatal("expected error from server")
@@ -708,7 +721,7 @@ func TestDownloadFile_ServerErrorIncludesPath(t *testing.T) {
 // error that already carries the path is passed through unchanged.
 func TestDownloadFile_ServerErrorWithPathNotDuplicated(t *testing.T) {
 	const serverErr = "/remote/loop/file.txt: too many levels of symbolic links"
-	ch := newMockChannel(makeJSONDataMsg(&Response{ID: 1, OK: false, Error: serverErr}))
+	ch := newMockChannel(makeResponseMsg(&Response{ID: 1, OK: false, Error: serverErr}))
 	err := downloadFile(ch, "/remote/loop/file.txt", filepath.Join(t.TempDir(), "out"), true, nil)
 	if err == nil || err.Error() != serverErr {
 		t.Fatalf("expected unchanged server error, got: %v", err)
@@ -722,7 +735,7 @@ func TestUploadFile_ServerErrorIncludesPath(t *testing.T) {
 	localPath := filepath.Join(tmp, "local.txt")
 	os.WriteFile(localPath, []byte("x"), 0644)
 
-	ch := newMockChannel(makeJSONDataMsg(&Response{ID: 1, OK: false, Error: "too many levels of symbolic links"}))
+	ch := newMockChannel(makeResponseMsg(&Response{ID: 1, OK: false, Error: "too many levels of symbolic links"}))
 	err := uploadFile(ch, localPath, "loop/out.txt", true, nil)
 	if err == nil {
 		t.Fatal("expected error from server")
@@ -739,7 +752,7 @@ func TestUploadFile(t *testing.T) {
 	os.WriteFile(localPath, content, 0644)
 
 	ch := newMockChannel(
-		makeJSONDataMsg(&Response{ID: 1, OK: true}),
+		makeResponseMsg(&Response{ID: 1, OK: true}),
 	)
 
 	// Verify that uploadFile sends the data through the channel without error.
@@ -758,14 +771,14 @@ func TestDownloadRecursive(t *testing.T) {
 	localRoot := filepath.Join(tmp, "downloaded")
 
 	ch := newMockChannel(
-		makeJSONDataMsg(&Response{ID: 1, OK: true, Info: &FileInfo{Name: "remote-dir", IsDir: true}}),
-		makeJSONDataMsg(&Response{ID: 2, OK: true, Entries: []FileInfo{{Name: "subdir", IsDir: true}, {Name: "file.txt", Size: 5, Mode: 0644}}}),
-		makeJSONDataMsg(&Response{ID: 3, OK: true, Info: &FileInfo{Name: "subdir", IsDir: true}}),
-		makeJSONDataMsg(&Response{ID: 4, OK: true, Entries: []FileInfo{{Name: "nested.txt", Size: 11, Mode: 0644}}}),
-		makeJSONDataMsg(&Response{ID: 5, OK: true, Data: []byte("hello world")}),
-		makeJSONDataMsg(&Response{ID: 6, OK: true, Data: []byte{}}),
-		makeJSONDataMsg(&Response{ID: 7, OK: true, Data: []byte("hello")}),
-		makeJSONDataMsg(&Response{ID: 8, OK: true, Data: []byte{}}),
+		makeResponseMsg(&Response{ID: 1, OK: true, Info: &FileInfo{Name: "remote-dir", IsDir: true}}),
+		makeResponseMsg(&Response{ID: 2, OK: true, Entries: []FileInfo{{Name: "subdir", IsDir: true}, {Name: "file.txt", Size: 5, Mode: 0644}}}),
+		makeResponseMsg(&Response{ID: 3, OK: true, Info: &FileInfo{Name: "subdir", IsDir: true}}),
+		makeResponseMsg(&Response{ID: 4, OK: true, Entries: []FileInfo{{Name: "nested.txt", Size: 11, Mode: 0644}}}),
+		makeResponseMsg(&Response{ID: 5, OK: true, Data: []byte("hello world")}),
+		makeResponseMsg(&Response{ID: 6, OK: true, Data: []byte{}}),
+		makeResponseMsg(&Response{ID: 7, OK: true, Data: []byte("hello")}),
+		makeResponseMsg(&Response{ID: 8, OK: true, Data: []byte{}}),
 	)
 
 	if err := downloadRecursive(ch, "remote-dir", localRoot, true, nil); err != nil {
@@ -797,11 +810,11 @@ func TestUploadRecursive(t *testing.T) {
 	os.WriteFile(filepath.Join(localRoot, "subdir", "nested.txt"), []byte("world"), 0644)
 
 	ch := newMockChannel(
-		makeJSONDataMsg(&Response{ID: 1, OK: false, Error: "no such file"}),
-		makeJSONDataMsg(&Response{ID: 2, OK: true}),
-		makeJSONDataMsg(&Response{ID: 3, OK: true}),
-		makeJSONDataMsg(&Response{ID: 4, OK: true, Info: &FileInfo{Name: "subdir", IsDir: true}}),
-		makeJSONDataMsg(&Response{ID: 5, OK: true}),
+		makeResponseMsg(&Response{ID: 1, OK: false, Error: "no such file"}),
+		makeResponseMsg(&Response{ID: 2, OK: true}),
+		makeResponseMsg(&Response{ID: 3, OK: true}),
+		makeResponseMsg(&Response{ID: 4, OK: true, Info: &FileInfo{Name: "subdir", IsDir: true}}),
+		makeResponseMsg(&Response{ID: 5, OK: true}),
 	)
 
 	if err := uploadRecursive(ch, localRoot, "remote-dir", true, nil); err != nil {
@@ -826,7 +839,7 @@ func TestUploadFile_DirectoryError(t *testing.T) {
 
 func TestDoRequest(t *testing.T) {
 	want := &Response{ID: 7, OK: true, Path: "/tmp"}
-	ch := newMockChannel(makeJSONDataMsg(want))
+	ch := newMockChannel(makeResponseMsg(want))
 	got, err := doRequest(ch, &Request{Cmd: "pwd"})
 	if err != nil {
 		t.Fatalf("doRequest error: %v", err)
@@ -839,7 +852,7 @@ func TestDoRequest(t *testing.T) {
 		t.Fatalf("expected 1 written request, got %d", len(ch.Writes))
 	}
 	var req Request
-	if err := json.Unmarshal(ch.Writes[0], &req); err != nil {
+	if err := decodeRequestFrame(ch.Writes[0], &req); err != nil {
 		t.Fatalf("unmarshal written request: %v", err)
 	}
 	if req.Cmd != "pwd" {
@@ -850,8 +863,12 @@ func TestDoRequest(t *testing.T) {
 // --- Chunked transfer size boundary tests ---
 
 func TestChunkSizeConstant(t *testing.T) {
-	if ChunkSize != 32*1024 {
-		t.Fatalf("ChunkSize expected %d, got %d", 32*1024, ChunkSize)
+	// Larger chunks amortise per-chunk framing and syscalls over more data,
+	// which is what makes pipelined transfers fast; 128 KiB is a power of
+	// two that keeps the in-flight transfer window (TransferWindow ×
+	// ChunkSize) well under a few MiB per direction.
+	if ChunkSize != 128*1024 {
+		t.Fatalf("ChunkSize expected %d, got %d", 128*1024, ChunkSize)
 	}
 	if TransferWindow < 1 {
 		t.Fatalf("TransferWindow must be at least 1, got %d", TransferWindow)
@@ -872,12 +889,12 @@ func TestDownloadFileContentsPipelined(t *testing.T) {
 	total := int64(n) * ChunkSize
 	var msgs []ssh3Messages.Message
 	for i := 0; i < n; i++ {
-		msgs = append(msgs, makeJSONDataMsg(&Response{ID: uint64(i + 1), OK: true, Data: bytes.Repeat([]byte{byte('a' + i)}, ChunkSize)}))
+		msgs = append(msgs, makeResponseMsg(&Response{ID: uint64(i + 1), OK: true, Data: bytes.Repeat([]byte{byte('a' + i)}, ChunkSize)}))
 	}
 	// Each data response triggers a refill request beyond the end of the
 	// file, which the server answers with an empty payload.
 	for i := 0; i < n; i++ {
-		msgs = append(msgs, makeJSONDataMsg(&Response{ID: uint64(n + i + 1), OK: true, Data: []byte{}}))
+		msgs = append(msgs, makeResponseMsg(&Response{ID: uint64(n + i + 1), OK: true, Data: []byte{}}))
 	}
 	// The initial window is min(TransferWindow, n); the channel must see the
 	// whole window before serving the first response.
@@ -908,7 +925,7 @@ func TestDownloadFileContentsPipelined(t *testing.T) {
 	var reqs []Request
 	for _, w := range ch.Writes {
 		var req Request
-		if err := json.Unmarshal(w, &req); err != nil {
+		if err := decodeRequestFrame(w, &req); err != nil {
 			t.Fatalf("unmarshal request: %v", err)
 		}
 		if req.Cmd != "get" || req.Limit != ChunkSize || req.Offset%ChunkSize != 0 {
@@ -939,7 +956,7 @@ func TestUploadFilePipelined(t *testing.T) {
 
 	var msgs []ssh3Messages.Message
 	for i := 0; i < n; i++ {
-		msgs = append(msgs, makeJSONDataMsg(&Response{ID: uint64(i + 1), OK: true}))
+		msgs = append(msgs, makeResponseMsg(&Response{ID: uint64(i + 1), OK: true}))
 	}
 	ch := newWindowedMockChannel(n, msgs...)
 
@@ -954,7 +971,7 @@ func TestUploadFilePipelined(t *testing.T) {
 	}
 	for i, w := range ch.Writes {
 		var req Request
-		if err := json.Unmarshal(w, &req); err != nil {
+		if err := decodeRequestFrame(w, &req); err != nil {
 			t.Fatalf("unmarshal request %d: %v", i, err)
 		}
 		if req.Cmd != "put" || req.Offset != int64(i)*ChunkSize {
@@ -979,13 +996,13 @@ func TestDownloadFileContentsShortFinalChunk(t *testing.T) {
 	total := int64(n)*ChunkSize + 1234
 	var msgs []ssh3Messages.Message
 	for i := 0; i < n; i++ {
-		msgs = append(msgs, makeJSONDataMsg(&Response{ID: uint64(i + 1), OK: true, Data: bytes.Repeat([]byte{byte('a' + i)}, ChunkSize)}))
+		msgs = append(msgs, makeResponseMsg(&Response{ID: uint64(i + 1), OK: true, Data: bytes.Repeat([]byte{byte('a' + i)}, ChunkSize)}))
 	}
-	msgs = append(msgs, makeJSONDataMsg(&Response{ID: 4, OK: true, Data: bytes.Repeat([]byte{'d'}, 1234)}))
+	msgs = append(msgs, makeResponseMsg(&Response{ID: 4, OK: true, Data: bytes.Repeat([]byte{'d'}, 1234)}))
 	// The four data responses each trigger a refill request beyond the end of
 	// the file, answered with an empty payload.
 	for i := 0; i < 4; i++ {
-		msgs = append(msgs, makeJSONDataMsg(&Response{ID: 5 + uint64(i), OK: true, Data: []byte{}}))
+		msgs = append(msgs, makeResponseMsg(&Response{ID: 5 + uint64(i), OK: true, Data: []byte{}}))
 	}
 
 	ch := newWindowedMockChannel(4, msgs...)
@@ -1226,8 +1243,8 @@ func TestServeChannel_TwoRequests(t *testing.T) {
 
 	req1 := Request{Cmd: "pwd"}
 	req2 := Request{Cmd: "ls", Path: "."}
-	b1, _ := json.Marshal(req1)
-	b2, _ := json.Marshal(req2)
+	b1 := EncodeRequest(&req1)
+	b2 := EncodeRequest(&req2)
 
 	ch := newMockChannel(
 		makeDataMsg(b1),
@@ -1242,8 +1259,8 @@ func TestServeChannel_TwoRequests(t *testing.T) {
 	}
 	var resp1 Response
 	var resp2 Response
-	json.Unmarshal(ch.Writes[0], &resp1)
-	json.Unmarshal(ch.Writes[1], &resp2)
+	decodeResponseFrame(ch.Writes[0], &resp1)
+	decodeResponseFrame(ch.Writes[1], &resp2)
 
 	if !resp1.OK || resp1.Path != tmp {
 		t.Fatalf("unexpected resp1: %+v", resp1)
@@ -1259,16 +1276,12 @@ func TestServeChannel_TwoRequests(t *testing.T) {
 func TestServeChannel_ChunkedRequest(t *testing.T) {
 	tmp := t.TempDir()
 
-	// Build a put request whose JSON payload exceeds one channel data message
-	// (the base64 encoding of the data alone is larger than MaxPacketSize), so
+	// Build a put request whose frame exceeds one channel data message, so
 	// the request arrives split across several messages. The server must
 	// reassemble it before handling, mirroring the response-side reassembly.
-	payload := bytes.Repeat([]byte("abcdefghij"), 3000) // 30000 bytes
+	payload := bytes.Repeat([]byte("abcdefghij"), 3000) // 30000 bytes of data
 	req := Request{Cmd: "put", Path: filepath.Join(tmp, "big.bin"), Data: payload}
-	raw, err := json.Marshal(req)
-	if err != nil {
-		t.Fatalf("marshal: %v", err)
-	}
+	raw := EncodeRequest(&req)
 	msgs := splitIntoChannelMessages(raw)
 	if len(msgs) < 2 {
 		t.Fatalf("test request too small to be split across messages")
@@ -1282,7 +1295,7 @@ func TestServeChannel_ChunkedRequest(t *testing.T) {
 		t.Fatalf("expected 1 response, got %d", len(ch.Writes))
 	}
 	var resp Response
-	if err := json.Unmarshal(ch.Writes[0], &resp); err != nil {
+	if err := decodeResponseFrame(ch.Writes[0], &resp); err != nil {
 		t.Fatalf("unmarshal response: %v", err)
 	}
 	if !resp.OK {
@@ -1381,8 +1394,7 @@ func (q *queuedMockChannel) waitResponses(n int) {
 }
 
 func writeRequest(req Request) *ssh3Messages.DataOrExtendedDataMessage {
-	b, _ := json.Marshal(req)
-	return makeDataMsg(b)
+	return makeDataMsg(EncodeRequest(&req))
 }
 
 func readResponses(t *testing.T, writes [][]byte, n int) []Response {
@@ -1392,7 +1404,7 @@ func readResponses(t *testing.T, writes [][]byte, n int) []Response {
 	}
 	resps := make([]Response, n)
 	for i, w := range writes {
-		if err := json.Unmarshal(w, &resps[i]); err != nil {
+		if err := decodeResponseFrame(w, &resps[i]); err != nil {
 			t.Fatalf("unmarshal response %d: %v", i, err)
 		}
 	}
@@ -1679,7 +1691,7 @@ func lsEntries(names ...string) []FileInfo {
 }
 
 func TestClientDoLsNoArg(t *testing.T) {
-	ch := newMockChannel(makeJSONDataMsg(&Response{
+	ch := newMockChannel(makeResponseMsg(&Response{
 		OK:      true,
 		Entries: lsEntries("."),
 	}))
@@ -1690,7 +1702,7 @@ func TestClientDoLsNoArg(t *testing.T) {
 	if len(ch.Writes) != 1 {
 		t.Fatalf("expected 1 request, got %d", len(ch.Writes))
 	}
-	if err := json.Unmarshal(ch.Writes[0], &got); err != nil {
+	if err := decodeRequestFrame(ch.Writes[0], &got); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
 	if got.Cmd != "ls" || got.Path != "/remote" {
@@ -1699,7 +1711,7 @@ func TestClientDoLsNoArg(t *testing.T) {
 }
 
 func TestClientDoLsWildcard(t *testing.T) {
-	ch := newMockChannel(makeJSONDataMsg(&Response{
+	ch := newMockChannel(makeResponseMsg(&Response{
 		OK:      true,
 		Entries: lsEntries("atest", "test", "testa", "test2", "nope"),
 	}))
@@ -1713,7 +1725,7 @@ func TestClientDoLsWildcard(t *testing.T) {
 	if len(ch.Writes) != 1 {
 		t.Fatalf("expected 1 request, got %d", len(ch.Writes))
 	}
-	if err := json.Unmarshal(ch.Writes[0], &got); err != nil {
+	if err := decodeRequestFrame(ch.Writes[0], &got); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
 	if got.Cmd != "ls" || got.Path != "/remote/path" {
@@ -1742,7 +1754,7 @@ func TestClientDoLsWildcard(t *testing.T) {
 }
 
 func TestClientDoLsNoMatch(t *testing.T) {
-	ch := newMockChannel(makeJSONDataMsg(&Response{
+	ch := newMockChannel(makeResponseMsg(&Response{
 		OK:      true,
 		Entries: lsEntries("one", "two"),
 	}))
@@ -1757,7 +1769,7 @@ func TestClientDoLsNoMatch(t *testing.T) {
 }
 
 func TestClientDoLsInvalidPattern(t *testing.T) {
-	ch := newMockChannel(makeJSONDataMsg(&Response{OK: true, Entries: lsEntries("a")}))
+	ch := newMockChannel(makeResponseMsg(&Response{OK: true, Entries: lsEntries("a")}))
 	err := doLs(ch, "/remote", []string{"ls", "["})
 	if err == nil {
 		t.Fatal("expected error for invalid glob pattern")
@@ -1768,9 +1780,9 @@ func TestClientDoGetNoGlob(t *testing.T) {
 	localDir := t.TempDir()
 
 	ch := newMockChannel(
-		makeJSONDataMsg(&Response{OK: true, Info: &FileInfo{Name: "remote.txt", Size: 5}}),
-		makeJSONDataMsg(&Response{OK: true, Data: []byte("hello")}),
-		makeJSONDataMsg(&Response{OK: true, Data: []byte{}}),
+		makeResponseMsg(&Response{OK: true, Info: &FileInfo{Name: "remote.txt", Size: 5}}),
+		makeResponseMsg(&Response{OK: true, Data: []byte("hello")}),
+		makeResponseMsg(&Response{OK: true, Data: []byte{}}),
 	)
 
 	if err := doGet(ch, localDir, "/remote", []string{"get", "remote.txt"}, true, nil); err != nil {
@@ -1781,7 +1793,7 @@ func TestClientDoGetNoGlob(t *testing.T) {
 	if len(ch.Writes) != 3 {
 		t.Fatalf("expected 3 requests, got %d", len(ch.Writes))
 	}
-	if err := json.Unmarshal(ch.Writes[0], &got); err != nil {
+	if err := decodeRequestFrame(ch.Writes[0], &got); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
 	if got.Cmd != "stat" || got.Path != "/remote/remote.txt" {
@@ -1800,13 +1812,13 @@ func TestClientDoGetWildcard(t *testing.T) {
 	localDir := t.TempDir()
 
 	ch := newMockChannel(
-		makeJSONDataMsg(&Response{OK: true, Entries: lsEntries("atest", "test", "testa", "nope")}),
-		makeJSONDataMsg(&Response{OK: true, Info: &FileInfo{Name: "test", Size: 5}}),
-		makeJSONDataMsg(&Response{OK: true, Data: []byte("hello")}),
-		makeJSONDataMsg(&Response{OK: true, Data: []byte{}}),
-		makeJSONDataMsg(&Response{OK: true, Info: &FileInfo{Name: "testa", Size: 5}}),
-		makeJSONDataMsg(&Response{OK: true, Data: []byte("world")}),
-		makeJSONDataMsg(&Response{OK: true, Data: []byte{}}),
+		makeResponseMsg(&Response{OK: true, Entries: lsEntries("atest", "test", "testa", "nope")}),
+		makeResponseMsg(&Response{OK: true, Info: &FileInfo{Name: "test", Size: 5}}),
+		makeResponseMsg(&Response{OK: true, Data: []byte("hello")}),
+		makeResponseMsg(&Response{OK: true, Data: []byte{}}),
+		makeResponseMsg(&Response{OK: true, Info: &FileInfo{Name: "testa", Size: 5}}),
+		makeResponseMsg(&Response{OK: true, Data: []byte("world")}),
+		makeResponseMsg(&Response{OK: true, Data: []byte{}}),
 	)
 
 	if err := doGet(ch, localDir, "/remote/path", []string{"get", "test*"}, true, nil); err != nil {
@@ -1817,7 +1829,7 @@ func TestClientDoGetWildcard(t *testing.T) {
 	if len(ch.Writes) != 7 {
 		t.Fatalf("expected 7 requests, got %d", len(ch.Writes))
 	}
-	if err := json.Unmarshal(ch.Writes[0], &got); err != nil {
+	if err := decodeRequestFrame(ch.Writes[0], &got); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
 	if got.Cmd != "ls" || got.Path != "/remote/path" {
@@ -1843,7 +1855,7 @@ func TestClientDoGetWildcard(t *testing.T) {
 func TestClientDoGetNoMatch(t *testing.T) {
 	localDir := t.TempDir()
 
-	ch := newMockChannel(makeJSONDataMsg(&Response{
+	ch := newMockChannel(makeResponseMsg(&Response{
 		OK:      true,
 		Entries: lsEntries("one", "two"),
 	}))
@@ -1864,7 +1876,7 @@ func TestClientDoGetNoMatch(t *testing.T) {
 }
 
 func TestClientDoGetInvalidPattern(t *testing.T) {
-	ch := newMockChannel(makeJSONDataMsg(&Response{OK: true, Entries: lsEntries("a")}))
+	ch := newMockChannel(makeResponseMsg(&Response{OK: true, Entries: lsEntries("a")}))
 	err := doGet(ch, t.TempDir(), "/remote", []string{"get", "["}, true, nil)
 	if err == nil {
 		t.Fatal("expected error for invalid glob pattern")
@@ -1875,10 +1887,10 @@ func TestClientDoGetRecursiveDir(t *testing.T) {
 	localDir := t.TempDir()
 
 	ch := newMockChannel(
-		makeJSONDataMsg(&Response{OK: true, Info: &FileInfo{Name: "d", IsDir: true}}),
-		makeJSONDataMsg(&Response{OK: true, Entries: []FileInfo{{Name: "f.txt", Size: 5, Mode: 0644}}}),
-		makeJSONDataMsg(&Response{OK: true, Data: []byte("hello")}),
-		makeJSONDataMsg(&Response{OK: true, Data: []byte{}}),
+		makeResponseMsg(&Response{OK: true, Info: &FileInfo{Name: "d", IsDir: true}}),
+		makeResponseMsg(&Response{OK: true, Entries: []FileInfo{{Name: "f.txt", Size: 5, Mode: 0644}}}),
+		makeResponseMsg(&Response{OK: true, Data: []byte("hello")}),
+		makeResponseMsg(&Response{OK: true, Data: []byte{}}),
 	)
 
 	if err := doGet(ch, localDir, "/remote", []string{"get", "-r", "d"}, true, nil); err != nil {
@@ -1904,20 +1916,20 @@ func TestClientDoGetRecursiveWildcard(t *testing.T) {
 	ch := newMockChannel(
 		// ls of the globbed parent directory: "atest" does not match "test*",
 		// "test" is a directory and "testa" a file.
-		makeJSONDataMsg(&Response{OK: true, Entries: []FileInfo{
+		makeResponseMsg(&Response{OK: true, Entries: []FileInfo{
 			{Name: "atest"},
 			{Name: "test", IsDir: true},
 			{Name: "testa", Size: 5, Mode: 0644},
 		}}),
 		// Recursing into the matched directory "test".
-		makeJSONDataMsg(&Response{OK: true, Info: &FileInfo{Name: "test", IsDir: true}}),
-		makeJSONDataMsg(&Response{OK: true, Entries: []FileInfo{{Name: "nested.txt", Size: 11, Mode: 0644}}}),
-		makeJSONDataMsg(&Response{OK: true, Data: []byte("hello world")}),
-		makeJSONDataMsg(&Response{OK: true, Data: []byte{}}),
+		makeResponseMsg(&Response{OK: true, Info: &FileInfo{Name: "test", IsDir: true}}),
+		makeResponseMsg(&Response{OK: true, Entries: []FileInfo{{Name: "nested.txt", Size: 11, Mode: 0644}}}),
+		makeResponseMsg(&Response{OK: true, Data: []byte("hello world")}),
+		makeResponseMsg(&Response{OK: true, Data: []byte{}}),
 		// Downloading the matched file "testa".
-		makeJSONDataMsg(&Response{OK: true, Info: &FileInfo{Name: "testa", Size: 5, Mode: 0644}}),
-		makeJSONDataMsg(&Response{OK: true, Data: []byte("world")}),
-		makeJSONDataMsg(&Response{OK: true, Data: []byte{}}),
+		makeResponseMsg(&Response{OK: true, Info: &FileInfo{Name: "testa", Size: 5, Mode: 0644}}),
+		makeResponseMsg(&Response{OK: true, Data: []byte("world")}),
+		makeResponseMsg(&Response{OK: true, Data: []byte{}}),
 	)
 
 	if err := doGet(ch, localDir, "/remote/path", []string{"get", "-r", "test*"}, true, nil); err != nil {
@@ -1951,7 +1963,7 @@ func TestClientDoGetRecursiveWildcard(t *testing.T) {
 		t.Fatalf("expected 8 requests, got %d", len(ch.Writes))
 	}
 	var got Request
-	if err := json.Unmarshal(ch.Writes[0], &got); err != nil {
+	if err := decodeRequestFrame(ch.Writes[0], &got); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
 	if got.Cmd != "ls" || got.Path != "/remote/path" {
@@ -1962,7 +1974,7 @@ func TestClientDoGetRecursiveWildcard(t *testing.T) {
 func TestClientDoGetRecursiveWildcardNoMatch(t *testing.T) {
 	localDir := t.TempDir()
 
-	ch := newMockChannel(makeJSONDataMsg(&Response{
+	ch := newMockChannel(makeResponseMsg(&Response{
 		OK:      true,
 		Entries: lsEntries("one", "two"),
 	}))
@@ -1989,8 +2001,8 @@ func TestClientDoPutWildcard(t *testing.T) {
 	os.WriteFile(filepath.Join(localDir, "c.log"), []byte("C"), 0644)
 
 	ch := newMockChannel(
-		makeJSONDataMsg(&Response{ID: 1, OK: true}), // put a.txt
-		makeJSONDataMsg(&Response{ID: 2, OK: true}), // put b.txt
+		makeResponseMsg(&Response{ID: 1, OK: true}), // put a.txt
+		makeResponseMsg(&Response{ID: 2, OK: true}), // put b.txt
 	)
 
 	if err := doPut(ch, localDir, "/remote", []string{"put", "*.txt"}, true, nil); err != nil {
@@ -2001,13 +2013,13 @@ func TestClientDoPutWildcard(t *testing.T) {
 		t.Fatalf("expected 2 requests, got %d", len(ch.Writes))
 	}
 	var got Request
-	if err := json.Unmarshal(ch.Writes[0], &got); err != nil {
+	if err := decodeRequestFrame(ch.Writes[0], &got); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
 	if got.Cmd != "put" || got.Path != "/remote/a.txt" {
 		t.Errorf("expected put /remote/a.txt, got %s %q", got.Cmd, got.Path)
 	}
-	if err := json.Unmarshal(ch.Writes[1], &got); err != nil {
+	if err := decodeRequestFrame(ch.Writes[1], &got); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
 	if got.Cmd != "put" || got.Path != "/remote/b.txt" {
@@ -2025,7 +2037,7 @@ func TestClientDoPutWildcardSubdirPattern(t *testing.T) {
 	os.WriteFile(filepath.Join(localDir, "sub", "two.TXT"), []byte("2"), 0644)
 	os.WriteFile(filepath.Join(localDir, "top.txt"), []byte("T"), 0644)
 
-	ch := newMockChannel(makeJSONDataMsg(&Response{ID: 1, OK: true}))
+	ch := newMockChannel(makeResponseMsg(&Response{ID: 1, OK: true}))
 
 	if err := doPut(ch, localDir, "/remote", []string{"put", "sub/*.txt"}, true, nil); err != nil {
 		t.Fatalf("doPut error: %v", err)
@@ -2034,7 +2046,7 @@ func TestClientDoPutWildcardSubdirPattern(t *testing.T) {
 		t.Fatalf("expected 1 request, got %d", len(ch.Writes))
 	}
 	var got Request
-	if err := json.Unmarshal(ch.Writes[0], &got); err != nil {
+	if err := decodeRequestFrame(ch.Writes[0], &got); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
 	if got.Cmd != "put" || got.Path != "/remote/one.txt" {
@@ -2051,9 +2063,9 @@ func TestClientDoPutWildcardToRemoteDir(t *testing.T) {
 	os.WriteFile(filepath.Join(localDir, "b.log"), []byte("B"), 0644)
 
 	ch := newMockChannel(
-		makeJSONDataMsg(&Response{ID: 1, OK: true, Info: &FileInfo{Name: "logs", IsDir: true}}), // stat /remote/logs
-		makeJSONDataMsg(&Response{ID: 2, OK: true}),                                             // put a.log
-		makeJSONDataMsg(&Response{ID: 3, OK: true}),                                             // put b.log
+		makeResponseMsg(&Response{ID: 1, OK: true, Info: &FileInfo{Name: "logs", IsDir: true}}), // stat /remote/logs
+		makeResponseMsg(&Response{ID: 2, OK: true}),                                             // put a.log
+		makeResponseMsg(&Response{ID: 3, OK: true}),                                             // put b.log
 	)
 
 	if err := doPut(ch, localDir, "/remote", []string{"put", "*.log", "logs"}, true, nil); err != nil {
@@ -2064,13 +2076,13 @@ func TestClientDoPutWildcardToRemoteDir(t *testing.T) {
 		t.Fatalf("expected 3 requests, got %d", len(ch.Writes))
 	}
 	var got Request
-	if err := json.Unmarshal(ch.Writes[1], &got); err != nil {
+	if err := decodeRequestFrame(ch.Writes[1], &got); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
 	if got.Cmd != "put" || got.Path != "/remote/logs/a.log" {
 		t.Errorf("expected put /remote/logs/a.log, got %s %q", got.Cmd, got.Path)
 	}
-	if err := json.Unmarshal(ch.Writes[2], &got); err != nil {
+	if err := decodeRequestFrame(ch.Writes[2], &got); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
 	if got.Cmd != "put" || got.Path != "/remote/logs/b.log" {
@@ -2085,7 +2097,7 @@ func TestClientDoPutWildcardToNonDirectory(t *testing.T) {
 	os.WriteFile(filepath.Join(localDir, "a.log"), []byte("A"), 0644)
 	os.WriteFile(filepath.Join(localDir, "b.log"), []byte("B"), 0644)
 
-	ch := newMockChannel(makeJSONDataMsg(&Response{ID: 1, OK: false, Error: "no such file"}))
+	ch := newMockChannel(makeResponseMsg(&Response{ID: 1, OK: false, Error: "no such file"}))
 
 	err := doPut(ch, localDir, "/remote", []string{"put", "*.log", "logs"}, true, nil)
 	if err == nil {
@@ -2103,8 +2115,8 @@ func TestClientDoPutSingleToRemoteDir(t *testing.T) {
 	os.WriteFile(filepath.Join(localDir, "a.txt"), []byte("A"), 0644)
 
 	ch := newMockChannel(
-		makeJSONDataMsg(&Response{ID: 1, OK: true, Info: &FileInfo{Name: "dir", IsDir: true}}),
-		makeJSONDataMsg(&Response{ID: 2, OK: true}),
+		makeResponseMsg(&Response{ID: 1, OK: true, Info: &FileInfo{Name: "dir", IsDir: true}}),
+		makeResponseMsg(&Response{ID: 2, OK: true}),
 	)
 
 	if err := doPut(ch, localDir, "/remote", []string{"put", "a.txt", "dir"}, true, nil); err != nil {
@@ -2114,7 +2126,7 @@ func TestClientDoPutSingleToRemoteDir(t *testing.T) {
 		t.Fatalf("expected 2 requests, got %d", len(ch.Writes))
 	}
 	var got Request
-	if err := json.Unmarshal(ch.Writes[1], &got); err != nil {
+	if err := decodeRequestFrame(ch.Writes[1], &got); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
 	if got.Cmd != "put" || got.Path != "/remote/dir/a.txt" {
@@ -2130,8 +2142,8 @@ func TestClientDoPutSingleToNewName(t *testing.T) {
 	os.WriteFile(filepath.Join(localDir, "a.txt"), []byte("A"), 0644)
 
 	ch := newMockChannel(
-		makeJSONDataMsg(&Response{ID: 1, OK: false, Error: "no such file"}),
-		makeJSONDataMsg(&Response{ID: 2, OK: true}),
+		makeResponseMsg(&Response{ID: 1, OK: false, Error: "no such file"}),
+		makeResponseMsg(&Response{ID: 2, OK: true}),
 	)
 
 	if err := doPut(ch, localDir, "/remote", []string{"put", "a.txt", "newname"}, true, nil); err != nil {
@@ -2141,7 +2153,7 @@ func TestClientDoPutSingleToNewName(t *testing.T) {
 		t.Fatalf("expected 2 requests, got %d", len(ch.Writes))
 	}
 	var got Request
-	if err := json.Unmarshal(ch.Writes[1], &got); err != nil {
+	if err := decodeRequestFrame(ch.Writes[1], &got); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
 	if got.Cmd != "put" || got.Path != "/remote/newname" {
@@ -2156,7 +2168,7 @@ func TestClientDoPutEscapedGlob(t *testing.T) {
 	localDir := t.TempDir()
 	os.WriteFile(filepath.Join(localDir, "star*file"), []byte("S"), 0644)
 
-	ch := newMockChannel(makeJSONDataMsg(&Response{ID: 1, OK: true}))
+	ch := newMockChannel(makeResponseMsg(&Response{ID: 1, OK: true}))
 
 	// parts[1] is what makeargv produces for the typed `star\*file`.
 	if err := doPut(ch, localDir, "/remote", []string{"put", `star\*file`}, true, nil); err != nil {
@@ -2166,7 +2178,7 @@ func TestClientDoPutEscapedGlob(t *testing.T) {
 		t.Fatalf("expected 1 request, got %d", len(ch.Writes))
 	}
 	var got Request
-	if err := json.Unmarshal(ch.Writes[0], &got); err != nil {
+	if err := decodeRequestFrame(ch.Writes[0], &got); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
 	if got.Cmd != "put" || got.Path != "/remote/star*file" {
@@ -2193,7 +2205,7 @@ func TestClientDoPutQuotedMetachar(t *testing.T) {
 		t.Fatalf("expected escaped source %q, got %q", `star\*file`, parts[1])
 	}
 
-	ch := newMockChannel(makeJSONDataMsg(&Response{OK: true}))
+	ch := newMockChannel(makeResponseMsg(&Response{OK: true}))
 	if err := doPut(ch, localDir, "/remote", parts, true, nil); err != nil {
 		t.Fatalf("doPut error: %v", err)
 	}
@@ -2202,7 +2214,7 @@ func TestClientDoPutQuotedMetachar(t *testing.T) {
 	if len(ch.Writes) != 1 {
 		t.Fatalf("expected 1 request, got %d", len(ch.Writes))
 	}
-	if err := json.Unmarshal(ch.Writes[0], &got); err != nil {
+	if err := decodeRequestFrame(ch.Writes[0], &got); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
 	if got.Cmd != "put" || got.Path != "/remote/star*file" {
@@ -2247,11 +2259,11 @@ func TestClientDoPutRecursiveWildcard(t *testing.T) {
 	os.WriteFile(filepath.Join(localDir, "solo.txt"), []byte("solo"), 0644)
 
 	ch := newMockChannel(
-		makeJSONDataMsg(&Response{ID: 1, OK: false, Error: "no such file"}),                       // stat /remote/d
-		makeJSONDataMsg(&Response{ID: 2, OK: true, Info: &FileInfo{Name: "remote", IsDir: true}}), // stat /remote
-		makeJSONDataMsg(&Response{ID: 3, OK: true}),                                               // mkdir /remote/d
-		makeJSONDataMsg(&Response{ID: 4, OK: true}),                                               // put /remote/d/f.txt
-		makeJSONDataMsg(&Response{ID: 5, OK: true}),                                               // put /remote/solo.txt
+		makeResponseMsg(&Response{ID: 1, OK: false, Error: "no such file"}),                       // stat /remote/d
+		makeResponseMsg(&Response{ID: 2, OK: true, Info: &FileInfo{Name: "remote", IsDir: true}}), // stat /remote
+		makeResponseMsg(&Response{ID: 3, OK: true}),                                               // mkdir /remote/d
+		makeResponseMsg(&Response{ID: 4, OK: true}),                                               // put /remote/d/f.txt
+		makeResponseMsg(&Response{ID: 5, OK: true}),                                               // put /remote/solo.txt
 	)
 
 	if err := doPut(ch, localDir, "/remote", []string{"put", "-r", "*"}, true, nil); err != nil {
@@ -2261,13 +2273,13 @@ func TestClientDoPutRecursiveWildcard(t *testing.T) {
 		t.Fatalf("expected 5 requests, got %d", len(ch.Writes))
 	}
 	var mkdirReq, putReq Request
-	if err := json.Unmarshal(ch.Writes[2], &mkdirReq); err != nil {
+	if err := decodeRequestFrame(ch.Writes[2], &mkdirReq); err != nil {
 		t.Fatalf("unmarshal mkdir: %v", err)
 	}
 	if mkdirReq.Cmd != "mkdir" || mkdirReq.Path != "/remote/d" {
 		t.Errorf("expected mkdir /remote/d, got %s %q", mkdirReq.Cmd, mkdirReq.Path)
 	}
-	if err := json.Unmarshal(ch.Writes[4], &putReq); err != nil {
+	if err := decodeRequestFrame(ch.Writes[4], &putReq); err != nil {
 		t.Fatalf("unmarshal put: %v", err)
 	}
 	if putReq.Cmd != "put" || putReq.Path != "/remote/solo.txt" {
@@ -2284,13 +2296,13 @@ func TestClientDoGetWildcardToLocalDir(t *testing.T) {
 	os.MkdirAll(destDir, 0o755)
 
 	ch := newMockChannel(
-		makeJSONDataMsg(&Response{OK: true, Entries: lsEntries("test", "testa", "nope")}),
-		makeJSONDataMsg(&Response{OK: true, Info: &FileInfo{Name: "test", Size: 5}}),
-		makeJSONDataMsg(&Response{OK: true, Data: []byte("hello")}),
-		makeJSONDataMsg(&Response{OK: true, Data: []byte{}}),
-		makeJSONDataMsg(&Response{OK: true, Info: &FileInfo{Name: "testa", Size: 5}}),
-		makeJSONDataMsg(&Response{OK: true, Data: []byte("world")}),
-		makeJSONDataMsg(&Response{OK: true, Data: []byte{}}),
+		makeResponseMsg(&Response{OK: true, Entries: lsEntries("test", "testa", "nope")}),
+		makeResponseMsg(&Response{OK: true, Info: &FileInfo{Name: "test", Size: 5}}),
+		makeResponseMsg(&Response{OK: true, Data: []byte("hello")}),
+		makeResponseMsg(&Response{OK: true, Data: []byte{}}),
+		makeResponseMsg(&Response{OK: true, Info: &FileInfo{Name: "testa", Size: 5}}),
+		makeResponseMsg(&Response{OK: true, Data: []byte("world")}),
+		makeResponseMsg(&Response{OK: true, Data: []byte{}}),
 	)
 
 	if err := doGet(ch, localDir, "/remote/path", []string{"get", "test*", "dest"}, true, nil); err != nil {
@@ -2300,7 +2312,7 @@ func TestClientDoGetWildcardToLocalDir(t *testing.T) {
 	// The ls request must target the source parent directory, not the
 	// destination.
 	var got Request
-	if err := json.Unmarshal(ch.Writes[0], &got); err != nil {
+	if err := decodeRequestFrame(ch.Writes[0], &got); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
 	if got.Cmd != "ls" || got.Path != "/remote/path" {
@@ -2329,10 +2341,10 @@ func TestClientDoGetWildcardToTrailingSlashDir(t *testing.T) {
 	localDir := t.TempDir()
 
 	ch := newMockChannel(
-		makeJSONDataMsg(&Response{OK: true, Entries: lsEntries("test")}),
-		makeJSONDataMsg(&Response{OK: true, Info: &FileInfo{Name: "test", Size: 5}}),
-		makeJSONDataMsg(&Response{OK: true, Data: []byte("hello")}),
-		makeJSONDataMsg(&Response{OK: true, Data: []byte{}}),
+		makeResponseMsg(&Response{OK: true, Entries: lsEntries("test")}),
+		makeResponseMsg(&Response{OK: true, Info: &FileInfo{Name: "test", Size: 5}}),
+		makeResponseMsg(&Response{OK: true, Data: []byte("hello")}),
+		makeResponseMsg(&Response{OK: true, Data: []byte{}}),
 	)
 
 	if err := doGet(ch, localDir, "/remote/path", []string{"get", "test*", "newdir/"}, true, nil); err != nil {
@@ -2355,10 +2367,10 @@ func TestClientDoGetWildcardSingleToFile(t *testing.T) {
 	localDir := t.TempDir()
 
 	ch := newMockChannel(
-		makeJSONDataMsg(&Response{OK: true, Entries: lsEntries("test")}),
-		makeJSONDataMsg(&Response{OK: true, Info: &FileInfo{Name: "test", Size: 5}}),
-		makeJSONDataMsg(&Response{OK: true, Data: []byte("hello")}),
-		makeJSONDataMsg(&Response{OK: true, Data: []byte{}}),
+		makeResponseMsg(&Response{OK: true, Entries: lsEntries("test")}),
+		makeResponseMsg(&Response{OK: true, Info: &FileInfo{Name: "test", Size: 5}}),
+		makeResponseMsg(&Response{OK: true, Data: []byte("hello")}),
+		makeResponseMsg(&Response{OK: true, Data: []byte{}}),
 	)
 
 	if err := doGet(ch, localDir, "/remote/path", []string{"get", "test*", "out.txt"}, true, nil); err != nil {
@@ -2380,7 +2392,7 @@ func TestClientDoGetWildcardSingleToFile(t *testing.T) {
 func TestClientDoGetWildcardMultiToNonDir(t *testing.T) {
 	localDir := t.TempDir()
 
-	ch := newMockChannel(makeJSONDataMsg(&Response{OK: true, Entries: lsEntries("test", "testa")}))
+	ch := newMockChannel(makeResponseMsg(&Response{OK: true, Entries: lsEntries("test", "testa")}))
 
 	err := doGet(ch, localDir, "/remote/path", []string{"get", "test*", "out.txt"}, true, nil)
 	if err == nil {
@@ -2400,9 +2412,9 @@ func TestClientDoGetToExistingLocalDir(t *testing.T) {
 	os.MkdirAll(destDir, 0o755)
 
 	ch := newMockChannel(
-		makeJSONDataMsg(&Response{OK: true, Info: &FileInfo{Name: "remote.txt", Size: 5}}),
-		makeJSONDataMsg(&Response{OK: true, Data: []byte("hello")}),
-		makeJSONDataMsg(&Response{OK: true, Data: []byte{}}),
+		makeResponseMsg(&Response{OK: true, Info: &FileInfo{Name: "remote.txt", Size: 5}}),
+		makeResponseMsg(&Response{OK: true, Data: []byte("hello")}),
+		makeResponseMsg(&Response{OK: true, Data: []byte{}}),
 	)
 
 	if err := doGet(ch, localDir, "/remote", []string{"get", "remote.txt", "dest"}, true, nil); err != nil {
@@ -2425,9 +2437,9 @@ func TestClientDoGetToNewLocalName(t *testing.T) {
 	localDir := t.TempDir()
 
 	ch := newMockChannel(
-		makeJSONDataMsg(&Response{OK: true, Info: &FileInfo{Name: "remote.txt", Size: 5}}),
-		makeJSONDataMsg(&Response{OK: true, Data: []byte("hello")}),
-		makeJSONDataMsg(&Response{OK: true, Data: []byte{}}),
+		makeResponseMsg(&Response{OK: true, Info: &FileInfo{Name: "remote.txt", Size: 5}}),
+		makeResponseMsg(&Response{OK: true, Data: []byte("hello")}),
+		makeResponseMsg(&Response{OK: true, Data: []byte{}}),
 	)
 
 	newName := filepath.Join(localDir, "newname")
@@ -2452,9 +2464,9 @@ func TestClientDoGetToAbsoluteTarget(t *testing.T) {
 	target := filepath.Join(outDir, "absolute.txt")
 
 	ch := newMockChannel(
-		makeJSONDataMsg(&Response{OK: true, Info: &FileInfo{Name: "remote.txt", Size: 5}}),
-		makeJSONDataMsg(&Response{OK: true, Data: []byte("hello")}),
-		makeJSONDataMsg(&Response{OK: true, Data: []byte{}}),
+		makeResponseMsg(&Response{OK: true, Info: &FileInfo{Name: "remote.txt", Size: 5}}),
+		makeResponseMsg(&Response{OK: true, Data: []byte("hello")}),
+		makeResponseMsg(&Response{OK: true, Data: []byte{}}),
 	)
 
 	if err := doGet(ch, localDir, "/remote", []string{"get", "remote.txt", target}, true, nil); err != nil {

--- a/sftp/symlink_test.go
+++ b/sftp/symlink_test.go
@@ -2,7 +2,6 @@ package sftp
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -115,10 +114,10 @@ func TestDownloadFileFollowsServerSymlink(t *testing.T) {
 
 	// stat link.txt -> symlink to real.txt; stat real.txt -> regular file.
 	ch := newMockChannel(
-		makeJSONDataMsg(&Response{ID: 1, OK: true, Info: &FileInfo{Name: "link.txt", IsSymlink: true, LinkTarget: "real.txt"}}),
-		makeJSONDataMsg(&Response{ID: 2, OK: true, Info: &FileInfo{Name: "real.txt", Size: 5}}),
-		makeJSONDataMsg(&Response{ID: 3, OK: true, Data: []byte("hello")}),
-		makeJSONDataMsg(&Response{ID: 4, OK: true, Data: []byte{}}),
+		makeResponseMsg(&Response{ID: 1, OK: true, Info: &FileInfo{Name: "link.txt", IsSymlink: true, LinkTarget: "real.txt"}}),
+		makeResponseMsg(&Response{ID: 2, OK: true, Info: &FileInfo{Name: "real.txt", Size: 5}}),
+		makeResponseMsg(&Response{ID: 3, OK: true, Data: []byte("hello")}),
+		makeResponseMsg(&Response{ID: 4, OK: true, Data: []byte{}}),
 	)
 
 	if err := downloadFile(ch, "/remote/link.txt", localPath, true, nil); err != nil {
@@ -140,19 +139,19 @@ func TestDownloadFileFollowsServerSymlink(t *testing.T) {
 		t.Fatalf("expected 4 requests, got %d", len(ch.Writes))
 	}
 	var req Request
-	if err := json.Unmarshal(ch.Writes[0], &req); err != nil {
+	if err := decodeRequestFrame(ch.Writes[0], &req); err != nil {
 		t.Fatalf("unmarshal stat: %v", err)
 	}
 	if req.Cmd != "stat" || req.Path != "/remote/link.txt" {
 		t.Fatalf("expected stat /remote/link.txt, got %s %q", req.Cmd, req.Path)
 	}
-	if err := json.Unmarshal(ch.Writes[1], &req); err != nil {
+	if err := decodeRequestFrame(ch.Writes[1], &req); err != nil {
 		t.Fatalf("unmarshal stat: %v", err)
 	}
 	if req.Cmd != "stat" || req.Path != "/remote/real.txt" {
 		t.Fatalf("expected stat /remote/real.txt, got %s %q", req.Cmd, req.Path)
 	}
-	if err := json.Unmarshal(ch.Writes[2], &req); err != nil {
+	if err := decodeRequestFrame(ch.Writes[2], &req); err != nil {
 		t.Fatalf("unmarshal get: %v", err)
 	}
 	if req.Cmd != "get" || req.Path != "/remote/real.txt" {
@@ -165,16 +164,16 @@ func TestDownloadFileFollowsRelativeAndAbsoluteTargets(t *testing.T) {
 
 	// link -> ../other/real.txt (relative to the link's directory).
 	ch := newMockChannel(
-		makeJSONDataMsg(&Response{ID: 1, OK: true, Info: &FileInfo{Name: "link", IsSymlink: true, LinkTarget: "../other/real.txt"}}),
-		makeJSONDataMsg(&Response{ID: 2, OK: true, Info: &FileInfo{Name: "real.txt", Size: 4}}),
-		makeJSONDataMsg(&Response{ID: 3, OK: true, Data: []byte("data")}),
-		makeJSONDataMsg(&Response{ID: 4, OK: true, Data: []byte{}}),
+		makeResponseMsg(&Response{ID: 1, OK: true, Info: &FileInfo{Name: "link", IsSymlink: true, LinkTarget: "../other/real.txt"}}),
+		makeResponseMsg(&Response{ID: 2, OK: true, Info: &FileInfo{Name: "real.txt", Size: 4}}),
+		makeResponseMsg(&Response{ID: 3, OK: true, Data: []byte("data")}),
+		makeResponseMsg(&Response{ID: 4, OK: true, Data: []byte{}}),
 	)
 	if err := downloadFile(ch, "/home/u/sub/link", localPath, true, nil); err != nil {
 		t.Fatalf("downloadFile (relative target) error: %v", err)
 	}
 	var req Request
-	if err := json.Unmarshal(ch.Writes[1], &req); err != nil {
+	if err := decodeRequestFrame(ch.Writes[1], &req); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
 	if req.Path != "/home/u/other/real.txt" {
@@ -183,15 +182,15 @@ func TestDownloadFileFollowsRelativeAndAbsoluteTargets(t *testing.T) {
 
 	// link -> /etc/passwd (absolute target used verbatim).
 	ch2 := newMockChannel(
-		makeJSONDataMsg(&Response{ID: 1, OK: true, Info: &FileInfo{Name: "link", IsSymlink: true, LinkTarget: "/etc/passwd"}}),
-		makeJSONDataMsg(&Response{ID: 2, OK: true, Info: &FileInfo{Name: "passwd", Size: 4}}),
-		makeJSONDataMsg(&Response{ID: 3, OK: true, Data: []byte("data")}),
-		makeJSONDataMsg(&Response{ID: 4, OK: true, Data: []byte{}}),
+		makeResponseMsg(&Response{ID: 1, OK: true, Info: &FileInfo{Name: "link", IsSymlink: true, LinkTarget: "/etc/passwd"}}),
+		makeResponseMsg(&Response{ID: 2, OK: true, Info: &FileInfo{Name: "passwd", Size: 4}}),
+		makeResponseMsg(&Response{ID: 3, OK: true, Data: []byte("data")}),
+		makeResponseMsg(&Response{ID: 4, OK: true, Data: []byte{}}),
 	)
 	if err := downloadFile(ch2, "/home/u/link", localPath, true, nil); err != nil {
 		t.Fatalf("downloadFile (absolute target) error: %v", err)
 	}
-	if err := json.Unmarshal(ch2.Writes[1], &req); err != nil {
+	if err := decodeRequestFrame(ch2.Writes[1], &req); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
 	if req.Path != "/etc/passwd" {
@@ -201,7 +200,7 @@ func TestDownloadFileFollowsRelativeAndAbsoluteTargets(t *testing.T) {
 
 func TestDownloadFileNoFollowRejectsServerSymlink(t *testing.T) {
 	ch := newMockChannel(
-		makeJSONDataMsg(&Response{ID: 1, OK: true, Info: &FileInfo{Name: "link.txt", IsSymlink: true, LinkTarget: "real.txt"}}),
+		makeResponseMsg(&Response{ID: 1, OK: true, Info: &FileInfo{Name: "link.txt", IsSymlink: true, LinkTarget: "real.txt"}}),
 	)
 
 	err := downloadFile(ch, "/remote/link.txt", filepath.Join(t.TempDir(), "out"), false, nil)
@@ -222,7 +221,7 @@ func TestDownloadFileFollowSymlinkLoop(t *testing.T) {
 	// returns the same symlink for each of the fatal-link resolution hops.
 	var msgs []ssh3Messages.Message
 	for i := 0; i < maxSymlinkFollow; i++ {
-		msgs = append(msgs, makeJSONDataMsg(&Response{ID: uint64(i + 1), OK: true, Info: &FileInfo{Name: "loop", IsSymlink: true, LinkTarget: "loop"}}))
+		msgs = append(msgs, makeResponseMsg(&Response{ID: uint64(i + 1), OK: true, Info: &FileInfo{Name: "loop", IsSymlink: true, LinkTarget: "loop"}}))
 	}
 	ch := newMockChannel(msgs...)
 	err := downloadFile(ch, "/remote/loop", filepath.Join(t.TempDir(), "out"), true, nil)
@@ -240,18 +239,18 @@ func TestDownloadRecursiveFollowsServerSymlinkToDir(t *testing.T) {
 
 	// remote-dir/ contains a symlink "dirlink" -> "sub" (a directory).
 	ch := newMockChannel(
-		makeJSONDataMsg(&Response{ID: 1, OK: true, Info: &FileInfo{Name: "remote-dir", IsDir: true}}),
-		makeJSONDataMsg(&Response{ID: 2, OK: true, Entries: []FileInfo{
+		makeResponseMsg(&Response{ID: 1, OK: true, Info: &FileInfo{Name: "remote-dir", IsDir: true}}),
+		makeResponseMsg(&Response{ID: 2, OK: true, Entries: []FileInfo{
 			{Name: "file.txt", Size: 5, Mode: 0644},
 			{Name: "dirlink", IsSymlink: true, LinkTarget: "sub"},
 		}}),
-		makeJSONDataMsg(&Response{ID: 3, OK: true, Data: []byte("hello")}),
-		makeJSONDataMsg(&Response{ID: 4, OK: true, Data: []byte{}}),
+		makeResponseMsg(&Response{ID: 3, OK: true, Data: []byte("hello")}),
+		makeResponseMsg(&Response{ID: 4, OK: true, Data: []byte{}}),
 		// Following dirlink: stat resolves sub, ls sub.
-		makeJSONDataMsg(&Response{ID: 5, OK: true, Info: &FileInfo{Name: "sub", IsDir: true}}),
-		makeJSONDataMsg(&Response{ID: 6, OK: true, Entries: []FileInfo{{Name: "nested.txt", Size: 11, Mode: 0644}}}),
-		makeJSONDataMsg(&Response{ID: 7, OK: true, Data: []byte("hello world")}),
-		makeJSONDataMsg(&Response{ID: 8, OK: true, Data: []byte{}}),
+		makeResponseMsg(&Response{ID: 5, OK: true, Info: &FileInfo{Name: "sub", IsDir: true}}),
+		makeResponseMsg(&Response{ID: 6, OK: true, Entries: []FileInfo{{Name: "nested.txt", Size: 11, Mode: 0644}}}),
+		makeResponseMsg(&Response{ID: 7, OK: true, Data: []byte("hello world")}),
+		makeResponseMsg(&Response{ID: 8, OK: true, Data: []byte{}}),
 	)
 
 	if err := downloadRecursive(ch, "remote-dir", localRoot, true, nil); err != nil {
@@ -278,10 +277,10 @@ func TestDownloadRecursiveNoFollowRejectsServerSymlink(t *testing.T) {
 	localRoot := filepath.Join(t.TempDir(), "downloaded")
 
 	ch := newMockChannel(
-		makeJSONDataMsg(&Response{ID: 1, OK: true, Info: &FileInfo{Name: "remote-dir", IsDir: true}}),
+		makeResponseMsg(&Response{ID: 1, OK: true, Info: &FileInfo{Name: "remote-dir", IsDir: true}}),
 		// The symlink entry comes first so it is rejected before any file chunk
 		// request is attempted.
-		makeJSONDataMsg(&Response{ID: 2, OK: true, Entries: []FileInfo{
+		makeResponseMsg(&Response{ID: 2, OK: true, Entries: []FileInfo{
 			{Name: "dirlink", IsSymlink: true, LinkTarget: "sub"},
 			{Name: "file.txt", Size: 5, Mode: 0644},
 		}}),
@@ -305,7 +304,7 @@ func TestUploadFileFollowsLocalSymlink(t *testing.T) {
 		t.Skipf("cannot create symlink: %v", err)
 	}
 
-	ch := newMockChannel(makeJSONDataMsg(&Response{ID: 1, OK: true}))
+	ch := newMockChannel(makeResponseMsg(&Response{ID: 1, OK: true}))
 
 	if err := uploadFile(ch, filepath.Join(tmp, "link.txt"), "/remote/link.txt", true, nil); err != nil {
 		t.Fatalf("uploadFile error: %v", err)
@@ -315,7 +314,7 @@ func TestUploadFileFollowsLocalSymlink(t *testing.T) {
 	}
 	// The target's content must be uploaded, not the link itself.
 	var req Request
-	if err := json.Unmarshal(ch.Writes[0], &req); err != nil {
+	if err := decodeRequestFrame(ch.Writes[0], &req); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
 	if string(req.Data) != "upload me" {
@@ -370,17 +369,17 @@ func TestUploadRecursiveFollowsLocalSymlinkToDir(t *testing.T) {
 	//     mkdir("remote-dir/sub") -> ok
 	//   upload nested.txt: put("remote-dir/sub/nested.txt") -> ok
 	ch := newMockChannel(
-		makeJSONDataMsg(&Response{ID: 1, OK: false, Error: "no such file"}),
-		makeJSONDataMsg(&Response{ID: 2, OK: true}),
-		makeJSONDataMsg(&Response{ID: 3, OK: false, Error: "no such file"}),
-		makeJSONDataMsg(&Response{ID: 4, OK: true, Info: &FileInfo{Name: "remote-dir", IsDir: true}}),
-		makeJSONDataMsg(&Response{ID: 5, OK: true}),
-		makeJSONDataMsg(&Response{ID: 6, OK: true}),
-		makeJSONDataMsg(&Response{ID: 7, OK: true}),
-		makeJSONDataMsg(&Response{ID: 8, OK: false, Error: "no such file"}),
-		makeJSONDataMsg(&Response{ID: 9, OK: true, Info: &FileInfo{Name: "remote-dir", IsDir: true}}),
-		makeJSONDataMsg(&Response{ID: 10, OK: true}),
-		makeJSONDataMsg(&Response{ID: 11, OK: true}),
+		makeResponseMsg(&Response{ID: 1, OK: false, Error: "no such file"}),
+		makeResponseMsg(&Response{ID: 2, OK: true}),
+		makeResponseMsg(&Response{ID: 3, OK: false, Error: "no such file"}),
+		makeResponseMsg(&Response{ID: 4, OK: true, Info: &FileInfo{Name: "remote-dir", IsDir: true}}),
+		makeResponseMsg(&Response{ID: 5, OK: true}),
+		makeResponseMsg(&Response{ID: 6, OK: true}),
+		makeResponseMsg(&Response{ID: 7, OK: true}),
+		makeResponseMsg(&Response{ID: 8, OK: false, Error: "no such file"}),
+		makeResponseMsg(&Response{ID: 9, OK: true, Info: &FileInfo{Name: "remote-dir", IsDir: true}}),
+		makeResponseMsg(&Response{ID: 10, OK: true}),
+		makeResponseMsg(&Response{ID: 11, OK: true}),
 	)
 
 	if err := uploadRecursive(ch, localRoot, "remote-dir", true, nil); err != nil {
@@ -394,7 +393,7 @@ func TestUploadRecursiveFollowsLocalSymlinkToDir(t *testing.T) {
 	var putReq Request
 	found := false
 	for _, w := range ch.Writes {
-		if err := json.Unmarshal(w, &putReq); err != nil {
+		if err := decodeRequestFrame(w, &putReq); err != nil {
 			t.Fatalf("unmarshal: %v", err)
 		}
 		if putReq.Cmd == "put" && putReq.Path == "remote-dir/dirlink/nested.txt" {
@@ -422,8 +421,8 @@ func TestUploadRecursiveNoFollowRejectsLocalSymlink(t *testing.T) {
 	// ensured (stat miss, then mkdir). With follow=false it is then rejected
 	// as a symbolic link.
 	ch := newMockChannel(
-		makeJSONDataMsg(&Response{ID: 1, OK: false, Error: "no such file"}),
-		makeJSONDataMsg(&Response{ID: 2, OK: true}),
+		makeResponseMsg(&Response{ID: 1, OK: false, Error: "no such file"}),
+		makeResponseMsg(&Response{ID: 2, OK: true}),
 	)
 	err := uploadRecursive(ch, localRoot, "remote-dir", false, nil)
 	if err == nil {
@@ -440,7 +439,7 @@ func requestPaths(writes [][]byte) []string {
 	var out []string
 	for _, w := range writes {
 		var req Request
-		if err := json.Unmarshal(w, &req); err != nil {
+		if err := decodeRequestFrame(w, &req); err != nil {
 			out = append(out, "<unparseable>")
 			continue
 		}


### PR DESCRIPTION
The SFTP client and server exchanged requests and responses as JSON, which base64-encodes []byte data fields. That added roughly 33% wire expansion to every transfer chunk plus per-chunk JSON marshal/unmarshal CPU cost.

Replace it with a self-delimiting binary protocol (4-byte length prefix + compact payload) that carries file data as raw bytes, uses fixed-width integers and length-prefixed strings instead of field names, and encodes commands as single bytes. Bump ChunkSize from 32KiB to 128KiB to amortise per-chunk framing and syscalls, and reuse pooled send-side frame buffers and a single upload chunk buffer to remove per-chunk allocations.

Per 128KiB chunk (round trip): wire bytes 349.6KB -> 262.2KB (-25%); decode 820us -> 51ns; encode 106us -> 18us.

The length-prefixed framing composes with QUIC message fragmentation and the root->child stdio proxy. All unit tests (incl. -race) and the live scp/interactive-sftp integration tests pass.