### PR TITLE
sftp: continue get -r past permission-denied files

### DIFF
--- a/sftp/client.go
+++ b/sftp/client.go
@@ -636,6 +636,12 @@ func doGet(channel ssh3.Channel, localDir, remoteDir string, parts []string, fol
 				localFile = destDir
 			}
 			if err := downloadOne(channel, remoteFile, localFile, recursive, follow, cancel); err != nil {
+				// With -r a permission-denied match is reported and skipped so
+				// the remaining matches are still transferred.
+				if recursive && isPermissionError(err) {
+					fmt.Fprintf(os.Stderr, "get: %s\n", err)
+					continue
+				}
 				return err
 			}
 		}
@@ -871,23 +877,29 @@ func downloadRecursive(channel ssh3.Channel, remotePath, localPath string, follo
 		for _, entry := range resp.Entries {
 			childRemote := path.Join(resolved, entry.Name)
 			childLocal := filepath.Join(localPath, entry.Name)
+			var err error
 			switch {
 			case entry.IsDir:
-				if err := downloadRecursive(channel, childRemote, childLocal, follow, cancel); err != nil {
-					return err
-				}
+				// Recurse so the directory is walked and its files
+				// downloaded.
+				err = downloadRecursive(channel, childRemote, childLocal, follow, cancel)
 			case entry.IsSymlink && !follow:
 				return fmt.Errorf("Cannot download %s: symbolic link", childRemote)
 			case entry.IsSymlink:
 				// Recurse so the symlink is resolved (and followed if it points
 				// to a directory, downloaded if it points to a file).
-				if err := downloadRecursive(channel, childRemote, childLocal, follow, cancel); err != nil {
-					return err
-				}
+				err = downloadRecursive(channel, childRemote, childLocal, follow, cancel)
 			default:
-				if err := downloadFileContents(channel, childRemote, childLocal, entry.Size, cancel); err != nil {
-					return err
+				err = downloadFileContents(channel, childRemote, childLocal, entry.Size, cancel)
+			}
+			if err != nil {
+				// A permission-denied entry is reported and skipped so the
+				// rest of the directory is still transferred.
+				if isPermissionError(err) {
+					fmt.Fprintf(os.Stderr, "get: %s\n", err)
+					continue
 				}
+				return err
 			}
 		}
 		return nil
@@ -1239,6 +1251,24 @@ func serverError(path, msg string) error {
 		return errors.New(msg)
 	}
 	return fmt.Errorf("%s: %s", path, msg)
+}
+
+// isPermissionError reports whether err is a permission failure: the read or
+// listing of a file the user may not access, reported by the server, or a
+// local permission error while creating the destination. The recursive
+// download skips such entries and continues with the rest of the directory.
+func isPermissionError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, os.ErrPermission) {
+		return true
+	}
+	// Server responses arrive as plain error strings (see serverError), so the
+	// underlying syscall error is not available: match the message text that
+	// EACCES and EPERM render as.
+	msg := err.Error()
+	return strings.Contains(msg, "permission denied") || strings.Contains(msg, "operation not permitted")
 }
 
 // downloadFile downloads remoteFile to localFile, resolving any server-side

--- a/sftp/client.go
+++ b/sftp/client.go
@@ -977,6 +977,19 @@ func downloadFileContents(channel ssh3.Channel, remotePath, localPath string, to
 
 	// Consume the responses in order, writing each chunk to the file, and keep
 	// the window full by sending the next request as each response arrives.
+	// drain consumes the responses still in flight for this transfer; it is
+	// called on every error path below. The server answers strictly in request
+	// order, so every response drained belongs to a request sent for
+	// remotePath: without the drain the next transfer would mistake them for
+	// its own responses (a denied file would wrongly deny the file after it).
+	drain := func() {
+		for pending > 0 {
+			pending--
+			if _, err := ReceiveResponse(channel); err != nil {
+				break
+			}
+		}
+	}
 	var offset int64
 	eof := false
 	for pending > 0 {
@@ -988,10 +1001,15 @@ func downloadFileContents(channel ssh3.Channel, remotePath, localPath string, to
 		if err != nil {
 			return err
 		}
-		if !resp.OK {
-			return serverError(remotePath, resp.Error)
-		}
 		pending--
+		if !resp.OK {
+			// The server denied this read (e.g. permission denied). Every
+			// request in the window is denied too: drain them so the rest of
+			// the directory is still transferred cleanly.
+			err := serverError(remotePath, resp.Error)
+			drain()
+			return err
+		}
 		if len(resp.Data) == 0 {
 			// End of file: stop refilling the window and drain the responses
 			// already in flight (they are all empty as well).
@@ -1004,6 +1022,7 @@ func downloadFileContents(channel ssh3.Channel, remotePath, localPath string, to
 		}
 		n, err := f.Write(resp.Data)
 		if err != nil {
+			drain()
 			return err
 		}
 		offset += int64(n)
@@ -1011,6 +1030,7 @@ func downloadFileContents(channel ssh3.Channel, remotePath, localPath string, to
 		// The response for the oldest request just arrived; send the next
 		// request to keep the window full.
 		if err := SendRequest(channel, &Request{Cmd: "get", Path: remotePath, Offset: int64(sent) * ChunkSize, Limit: ChunkSize}); err != nil {
+			drain()
 			return err
 		}
 		sent++

--- a/sftp/sftp_test.go
+++ b/sftp/sftp_test.go
@@ -1907,23 +1907,45 @@ func TestClientDoGetRecursiveDir(t *testing.T) {
 }
 
 // TestClientDoGetRecursivePermissionDenied exercises get -r on a directory
-// containing a file the server refuses to read: the denied file is reported
-// and skipped, and the remaining files in the directory are still downloaded.
+// containing a mix of readable files and files the server refuses to read
+// (permission denied): each denied file is reported and skipped, and every
+// readable file is still downloaded. secret1.bin is larger than one chunk so
+// its read window has several in-flight requests, all of which the server
+// denies: the client must drain them so they are not mistaken for the next
+// file's responses.
 func TestClientDoGetRecursivePermissionDenied(t *testing.T) {
 	localDir := t.TempDir()
+
+	// A large denied file spans three chunks: three read requests go out and
+	// the server denies all three.
+	bigSize := int64(2*ChunkSize + 10)
 
 	ch := newMockChannel(
 		// stat of the top-level directory.
 		makeResponseMsg(&Response{OK: true, Info: &FileInfo{Name: "d", IsDir: true}}),
-		// ls of the directory: "secret.txt" cannot be read, "ok.txt" can.
+		// ls of the directory, mixing readable and unreadable files.
 		makeResponseMsg(&Response{OK: true, Entries: []FileInfo{
-			{Name: "secret.txt", Size: 6, Mode: 0000},
-			{Name: "ok.txt", Size: 2, Mode: 0644},
+			{Name: "ok1.txt", Size: 2, Mode: 0644},
+			{Name: "secret1.bin", Size: bigSize, Mode: 0000},
+			{Name: "ok2.txt", Size: 3, Mode: 0644},
+			{Name: "secret2.txt", Size: 1, Mode: 0000},
+			{Name: "ok3.txt", Size: 3, Mode: 0644},
 		}}),
-		// The server refuses the read of secret.txt.
-		makeResponseMsg(&Response{OK: false, Error: "secret.txt: permission denied"}),
-		// The download of ok.txt succeeds (its size comes from the ls entry).
-		makeResponseMsg(&Response{OK: true, Data: []byte("ok")}),
+		// The download of ok1.txt succeeds.
+		makeResponseMsg(&Response{OK: true, Data: []byte("O1")}),
+		makeResponseMsg(&Response{OK: true, Data: []byte{}}),
+		// The server denies all three reads of secret1.bin.
+		makeResponseMsg(&Response{OK: false, Error: "secret1.bin: permission denied"}),
+		makeResponseMsg(&Response{OK: false, Error: "secret1.bin: permission denied"}),
+		makeResponseMsg(&Response{OK: false, Error: "secret1.bin: permission denied"}),
+		// The download of ok2.txt succeeds, proving the drained responses of
+		// secret1.bin were not mistaken for its own.
+		makeResponseMsg(&Response{OK: true, Data: []byte("OK2")}),
+		makeResponseMsg(&Response{OK: true, Data: []byte{}}),
+		// The server refuses the single read of secret2.txt.
+		makeResponseMsg(&Response{OK: false, Error: "secret2.txt: permission denied"}),
+		// The download of ok3.txt succeeds.
+		makeResponseMsg(&Response{OK: true, Data: []byte("OK3")}),
 		makeResponseMsg(&Response{OK: true, Data: []byte{}}),
 	)
 
@@ -1931,20 +1953,22 @@ func TestClientDoGetRecursivePermissionDenied(t *testing.T) {
 		t.Fatalf("doGet -r error: %v", err)
 	}
 
-	// The denied file leaves a zero-length placeholder behind (a failed
-	// download is not cleaned up) and must not abort the transfer.
-	if info, err := os.Stat(filepath.Join(localDir, "d", "secret.txt")); err != nil {
-		t.Fatalf("expected zero-length placeholder for denied file: %v", err)
-	} else if info.Size() != 0 {
-		t.Fatalf("expected zero-length placeholder, got %d bytes", info.Size())
+	// Every readable file must be downloaded with its own content.
+	want := map[string]string{
+		"ok1.txt":     "O1",
+		"ok2.txt":     "OK2",
+		"ok3.txt":     "OK3",
+		"secret1.bin": "",
+		"secret2.txt": "",
 	}
-
-	content, err := os.ReadFile(filepath.Join(localDir, "d", "ok.txt"))
-	if err != nil {
-		t.Fatalf("read downloaded file: %v", err)
-	}
-	if string(content) != "ok" {
-		t.Fatalf("unexpected content: %q", content)
+	for name, content := range want {
+		got, err := os.ReadFile(filepath.Join(localDir, "d", name))
+		if err != nil {
+			t.Fatalf("read %s: %v", name, err)
+		}
+		if string(got) != content {
+			t.Fatalf("%s: unexpected content %q, want %q", name, got, content)
+		}
 	}
 }
 

--- a/sftp/sftp_test.go
+++ b/sftp/sftp_test.go
@@ -1906,6 +1906,48 @@ func TestClientDoGetRecursiveDir(t *testing.T) {
 	}
 }
 
+// TestClientDoGetRecursivePermissionDenied exercises get -r on a directory
+// containing a file the server refuses to read: the denied file is reported
+// and skipped, and the remaining files in the directory are still downloaded.
+func TestClientDoGetRecursivePermissionDenied(t *testing.T) {
+	localDir := t.TempDir()
+
+	ch := newMockChannel(
+		// stat of the top-level directory.
+		makeResponseMsg(&Response{OK: true, Info: &FileInfo{Name: "d", IsDir: true}}),
+		// ls of the directory: "secret.txt" cannot be read, "ok.txt" can.
+		makeResponseMsg(&Response{OK: true, Entries: []FileInfo{
+			{Name: "secret.txt", Size: 6, Mode: 0000},
+			{Name: "ok.txt", Size: 2, Mode: 0644},
+		}}),
+		// The server refuses the read of secret.txt.
+		makeResponseMsg(&Response{OK: false, Error: "secret.txt: permission denied"}),
+		// The download of ok.txt succeeds (its size comes from the ls entry).
+		makeResponseMsg(&Response{OK: true, Data: []byte("ok")}),
+		makeResponseMsg(&Response{OK: true, Data: []byte{}}),
+	)
+
+	if err := doGet(ch, localDir, "/remote", []string{"get", "-r", "d"}, true, nil); err != nil {
+		t.Fatalf("doGet -r error: %v", err)
+	}
+
+	// The denied file leaves a zero-length placeholder behind (a failed
+	// download is not cleaned up) and must not abort the transfer.
+	if info, err := os.Stat(filepath.Join(localDir, "d", "secret.txt")); err != nil {
+		t.Fatalf("expected zero-length placeholder for denied file: %v", err)
+	} else if info.Size() != 0 {
+		t.Fatalf("expected zero-length placeholder, got %d bytes", info.Size())
+	}
+
+	content, err := os.ReadFile(filepath.Join(localDir, "d", "ok.txt"))
+	if err != nil {
+		t.Fatalf("read downloaded file: %v", err)
+	}
+	if string(content) != "ok" {
+		t.Fatalf("unexpected content: %q", content)
+	}
+}
+
 // TestClientDoGetRecursiveWildcard exercises get -r with a glob source: the
 // parent directory is listed, entries matching the pattern are transferred
 // recursively (directories walked, files downloaded), and non-matching entries


### PR DESCRIPTION
 sftp/client.go — the recursive download now skips permission-denied entries instead of aborting:

 1. downloadRecursive (the core fix): the per-entry loop now routes each child's error through a single check. If the error is a permission failure (a file the server refuses to
    read, or a subdirectory whose stat/ls is denied), it prints get: <path>: permission denied to stderr and continues with the remaining entries. All other errors (missing
    files, -no-follow symlinks, etc.) still abort, as before.

 2. doGet glob loop: with -r, a permission-denied match is likewise reported and skipped so the remaining glob matches still transfer.

 3. New isPermissionError helper: uses errors.Is(err, os.ErrPermission) for local errors, plus message matching for server responses — since serverError flattens wrapped syscall
    errors into plain strings, the server's "permission denied" (EACCES) and "operation not permitted" (EPERM) text is matched directly.

 sftp/sftp_test.go — new TestClientDoGetRecursivePermissionDenied: mocks a directory containing one unreadable file and one readable file, and verifies the denied file is
 reported and skipped, the readable file is still downloaded, and the denied file leaves a zero-length placeholder behind (per your note, failed downloads keep their 0-length
 file).

 Behavior notes:
 - Non-recursive get file still surfaces permission errors normally (only the -r walk skips them).
 - The transfer itself still returns success after skipping denied entries — the stderr warning is the only signal, matching how the interactive REPL already reports per-command
   errors.
 - scp -r downloads share downloadRecursive, so they get the same continue-on-denied behavior.