### PR TITLE
Expand tilde (~) to home directory in SFTP interactive mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,13 @@ To use sftp mode on the client, run this to drop into a SFTP shell:
 
 Type `help` in the `sftp>` prompt to see what commands are available.
 
+A leading `~` or `~/` in a path expands to the user's home directory, for
+every SFTP command: the *remote* user's home for remote arguments (`ls`,
+`mkdir`, `rm`, `rmdir`, the `get` source and `put` target) and the *local*
+user's home for local arguments (`lcd`, `lls`, the `get` target and `put`
+source). For example, `ls ~` lists the remote user's home and `lls ~` lists
+the local client user's home.
+
 Symbolic links are followed by default, both directions: `get` resolves
 server-side links (the server reports each link, the client follows it) and
 `put` resolves client-side links, including inside recursive transfers. Pass

--- a/sftp/client.go
+++ b/sftp/client.go
@@ -30,6 +30,14 @@ func RunInteractiveClient(c *client.Client, follow bool) error {
 	}
 
 	localDir, _ := os.Getwd()
+	// The local user's home directory, for tilde expansion of local paths
+	// (lcd, lls, the get target and put source).
+	localHome, _ := os.UserHomeDir()
+	if localHome != "" && !filepath.IsAbs(localHome) {
+		if abs, err := filepath.Abs(localHome); err == nil {
+			localHome = abs
+		}
+	}
 	remoteDir := "."
 	// The server starts every SFTP session in the authenticated user's home
 	// directory, so the first pwd reveals it. It backs the `cd`/`cd ~` →
@@ -49,7 +57,7 @@ func RunInteractiveClient(c *client.Client, follow bool) error {
 	}
 	defer input.close()
 	if input.editor != nil {
-		input.editor.completer = newCompleter(channel, &localDir, &remoteDir)
+		input.editor.completer = newCompleter(channel, &localDir, &remoteDir, homeDir, localHome)
 	}
 
 	for {
@@ -78,6 +86,11 @@ func RunInteractiveClient(c *client.Client, follow bool) error {
 
 		cmd := strings.ToLower(parts[0])
 
+		// Expand a leading "~" or "~/" in path arguments to the appropriate
+		// home directory before dispatching: the remote user's home for remote
+		// arguments, the local user's home for local ones.
+		expandCommandArgs(parts, homeDir, localHome)
+
 		switch cmd {
 		case "exit", "quit":
 			return nil
@@ -96,7 +109,7 @@ func RunInteractiveClient(c *client.Client, follow bool) error {
 		case "lls":
 			target := localDir
 			if len(parts) > 1 {
-				target = filepath.Join(localDir, undoGlobEscape(parts[1]))
+				target = resolveLocalPath(localDir, undoGlobEscape(parts[1]))
 			}
 			entries, err := os.ReadDir(target)
 			if err != nil {
@@ -273,6 +286,80 @@ func resolveCDTarget(arg, remoteDir, homeDir, prevDir string, hasPrevDir bool) (
 	}
 }
 
+// expandCommandArgs applies tilde expansion to the argument list of an SFTP
+// command line, replacing a leading "~" or "~/" in each path argument with
+// the appropriate home directory: the remote user's home for remote arguments
+// (ls, mkdir, rm, rmdir, the get source and put target) and the local user's
+// home for local arguments (lcd, lls, the get target and put source). The cd
+// command resolves "~" itself via resolveCDTarget and is left untouched.
+// parts is the argument list produced by makeargv and is mutated in place.
+func expandCommandArgs(parts []string, remoteHome, localHome string) {
+	cmd := strings.ToLower(parts[0])
+	expand := func(i int, home string, join func(...string) string) {
+		if i >= len(parts) {
+			return
+		}
+		parts[i] = expandTilde(parts[i], home, join)
+	}
+	switch cmd {
+	case "lcd", "lls":
+		expand(1, localHome, filepath.Join)
+	case "ls", "mkdir", "rm", "rmdir":
+		expand(1, remoteHome, path.Join)
+	case "get":
+		source, target := transferArgIndices(parts)
+		expand(source, remoteHome, path.Join)
+		expand(target, localHome, filepath.Join)
+	case "put":
+		source, target := transferArgIndices(parts)
+		expand(source, localHome, filepath.Join)
+		expand(target, remoteHome, path.Join)
+	}
+}
+
+// transferArgIndices returns the indexes of the source and target arguments
+// of a get/put command line, skipping flag arguments such as -r.
+func transferArgIndices(parts []string) (source, target int) {
+	source = 1
+	for source < len(parts) && strings.HasPrefix(parts[source], "-") {
+		source++
+	}
+	return source, source + 1
+}
+
+// expandTildePath expands a leading "~" or "~/" in a remote path to the
+// remote user's home directory.
+func expandTildePath(p, home string) string {
+	return expandTilde(p, home, path.Join)
+}
+
+// expandLocalTilde expands a leading "~" or "~/" in a local path to the
+// local user's home directory.
+func expandLocalTilde(p, home string) string {
+	return expandTilde(p, home, filepath.Join)
+}
+
+// expandTilde expands a leading "~" or "~/" in p to home, mirroring shell
+// tilde expansion for the current user: "~" alone becomes home itself and
+// "~/x" becomes home/x. A tilde elsewhere in the path, or one followed by a
+// character other than "/" (e.g. "~other"), is left unchanged. join cleans
+// the joined path (path.Join for remote paths, filepath.Join for local ones),
+// so "~/" with nothing after it yields home. When home is unknown ("") the
+// path is left unchanged so the command fails with the underlying error
+// instead of silently pointing at an empty path.
+func expandTilde(p, home string, join func(...string) string) string {
+	if home == "" {
+		return p
+	}
+	if p == "~" {
+		return home
+	}
+	if strings.HasPrefix(p, "~/") {
+		return join(home, p[2:])
+	}
+	return p
+}
+
 // newCompleter builds the tab-completion callback for the interactive SFTP
 // shell. It completes remote paths (resolved against *remoteDir, listed over
 // the sftp channel) for commands that operate on the remote filesystem, and
@@ -280,8 +367,9 @@ func resolveCDTarget(arg, remoteDir, homeDir, prevDir string, hasPrevDir bool) (
 // source argument is completed on the source side and the target argument on
 // the target side. Candidates are full replacements for the word being edited,
 // with directories ending in "/".
-func newCompleter(channel ssh3.Channel, localDir, remoteDir *string) completeFunc {
+func newCompleter(channel ssh3.Channel, localDir, remoteDir *string, homeDir, localHome string) completeFunc {
 	listRemote := func(dir string) ([]string, error) {
+		dir = expandTildePath(dir, homeDir)
 		if dir == "." {
 			dir = *remoteDir
 		} else if dir != "/" && !path.IsAbs(dir) {
@@ -306,6 +394,7 @@ func newCompleter(channel ssh3.Channel, localDir, remoteDir *string) completeFun
 	}
 
 	listLocal := func(dir string) ([]string, error) {
+		dir = expandLocalTilde(dir, localHome)
 		if dir == "." {
 			dir = *localDir
 		} else if !filepath.IsAbs(dir) {
@@ -431,7 +520,15 @@ func completePath(word string, listDir func(dir string) ([]string, error)) []str
 	dir := "."
 	prefix := word
 	base := "" // the word up to and including its last "/"
-	if i := strings.LastIndex(word, "/"); i >= 0 {
+	if word == "~" {
+		// A bare tilde: list the home directory and render its entries with
+		// the "~/" prefix the user typed, so the completed line expands to
+		// the same path. The listDir closure expands "~" to the actual home
+		// directory for the side being completed.
+		dir = "~"
+		base = "~/"
+		prefix = ""
+	} else if i := strings.LastIndex(word, "/"); i >= 0 {
 		base = word[:i+1]
 		dir = word[:i]
 		if dir == "" {
@@ -1168,7 +1265,12 @@ Paths are parsed like OpenSSH sftp: single quotes ('...') and double quotes
 character (e.g. get 'Downloads/Test File.txt' or put Test\ File.txt).
 A '#' outside quotes starts a comment. Tab completes file paths: local paths
 for lcd/lls and for the source of put and target of get; remote paths for all
-other arguments.`)
+other arguments.
+
+A leading "~" or "~/" in a path expands to the user's home directory: the
+remote user's home for remote arguments (ls, mkdir, rm, rmdir, the source of
+get and the target of put) and the local user's home for local arguments
+(lcd, lls, the target of get and the source of put).`)
 }
 
 func printEntry(name string, info os.FileInfo) {

--- a/sftp/completer_test.go
+++ b/sftp/completer_test.go
@@ -70,7 +70,7 @@ func TestCompleterRemote(t *testing.T) {
 	// three calls below issues an ls request.
 	ch := newMockChannel(resp, resp, resp)
 	localDir, remoteDir := "/local", "/remote"
-	c := newCompleter(ch, &localDir, &remoteDir)
+	c := newCompleter(ch, &localDir, &remoteDir, "/remote/home", "/local/home")
 
 	cands, start := c([]rune("cd fi"), 5)
 	if start != 3 {
@@ -116,7 +116,7 @@ func TestCompleterRemoteTrailingSlashListsDir(t *testing.T) {
 		FileInfo{Name: "util.go"},
 	)}))
 	localDir, remoteDir := "/local", "/remote"
-	c := newCompleter(ch, &localDir, &remoteDir)
+	c := newCompleter(ch, &localDir, &remoteDir, "/remote/home", "/local/home")
 
 	cands, start := c([]rune("cd docs/m"), 9)
 	if start != 3 {
@@ -141,7 +141,7 @@ func TestCompleterRemoteAbsolute(t *testing.T) {
 		FileInfo{Name: "usr", IsDir: true},
 	)}))
 	localDir, remoteDir := "/local", "/remote"
-	c := newCompleter(ch, &localDir, &remoteDir)
+	c := newCompleter(ch, &localDir, &remoteDir, "/remote/home", "/local/home")
 
 	cands, _ := c([]rune("ls /u"), 5)
 	if len(cands) != 1 || cands[0] != "/usr/" {
@@ -159,7 +159,7 @@ func TestCompleterRemoteAbsolute(t *testing.T) {
 func TestCompleterRemoteError(t *testing.T) {
 	ch := newMockChannel(makeResponseMsg(&Response{OK: false, Error: "no such file"}))
 	localDir, remoteDir := "/local", "/remote"
-	c := newCompleter(ch, &localDir, &remoteDir)
+	c := newCompleter(ch, &localDir, &remoteDir, "/remote/home", "/local/home")
 
 	if cands, _ := c([]rune("cd nope"), 7); cands != nil {
 		t.Errorf("error listing: got %v, want nil", cands)
@@ -175,7 +175,7 @@ func TestCompleterLocal(t *testing.T) {
 		t.Fatal(err)
 	}
 	localDir, remoteDir := dir, "/remote"
-	c := newCompleter(nil, &localDir, &remoteDir)
+	c := newCompleter(nil, &localDir, &remoteDir, "/remote/home", "/local/home")
 
 	cands, start := c([]rune("lls o"), 5)
 	if start != 4 {
@@ -208,7 +208,7 @@ func TestCompleterGetPutSides(t *testing.T) {
 		t.Fatal(err)
 	}
 	localDir, remoteDir := dir, "/remote"
-	c := newCompleter(ch, &localDir, &remoteDir)
+	c := newCompleter(ch, &localDir, &remoteDir, "/remote/home", "/local/home")
 
 	cands, _ := c([]rune("get r"), 5)
 	if len(cands) != 1 || cands[0] != "remote.txt" {
@@ -267,7 +267,7 @@ func TestEditorRemoteTabCompletion(t *testing.T) {
 		width:     80,
 		prompt:    "sftp> ",
 		histPos:   -1,
-		completer: newCompleter(q, &localDir, &remoteDir),
+		completer: newCompleter(q, &localDir, &remoteDir, "/remote/home", "/local/home"),
 	}
 	line := readWithTimeout(t, e, 5*time.Second)
 	if line != "cd src/main.go " {
@@ -318,5 +318,98 @@ func readWithTimeout(t *testing.T, e *lineEditor, d time.Duration) string {
 	case <-time.After(d):
 		t.Fatalf("line editor read timed out after %s", d)
 		return ""
+	}
+}
+
+// TestCompleterRemoteTilde verifies that a bare "~" completes to entries of
+// the remote home directory, rendered with the "~/" prefix the user typed.
+func TestCompleterRemoteTilde(t *testing.T) {
+	ch := newMockChannel(makeResponseMsg(&Response{OK: true, Entries: remoteEntries(
+		FileInfo{Name: "docs", IsDir: true},
+		FileInfo{Name: "id_rsa.pub"},
+	)}))
+	localDir, remoteDir := "/local", "/remote"
+	c := newCompleter(ch, &localDir, &remoteDir, "/home/alice", "/home/bob")
+
+	cands, start := c([]rune("ls ~"), 4)
+	if start != 3 {
+		t.Errorf("start = %d, want 3", start)
+	}
+	// A bare tilde lists the remote home, so the candidates carry the "~/"
+	// prefix and the request lists the expanded home directory.
+	if len(cands) != 2 || cands[0] != "~/docs/" || cands[1] != "~/id_rsa.pub" {
+		t.Errorf("candidates = %v, want [~/docs/ ~/id_rsa.pub]", cands)
+	}
+	var got Request
+	if err := decodeRequestFrame(ch.Writes[0], &got); err != nil {
+		t.Fatalf("unmarshal request: %v", err)
+	}
+	if got.Cmd != "ls" || got.Path != "/home/alice" {
+		t.Errorf("request = %s %q, want ls %q", got.Cmd, got.Path, "/home/alice")
+	}
+}
+
+// TestCompleterRemoteTildeSubdir verifies that completing a path under "~/"
+// lists the remote home and matches against the final component.
+func TestCompleterRemoteTildeSubdir(t *testing.T) {
+	ch := newMockChannel(makeResponseMsg(&Response{OK: true, Entries: remoteEntries(
+		FileInfo{Name: "doc.pdf"},
+		FileInfo{Name: "lib.go"},
+	)}))
+	localDir, remoteDir := "/local", "/remote"
+	c := newCompleter(ch, &localDir, &remoteDir, "/home/alice", "/home/bob")
+
+	cands, start := c([]rune("ls ~/do"), 6)
+	if start != 3 {
+		t.Errorf("start = %d, want 3", start)
+	}
+	if len(cands) != 1 || cands[0] != "~/doc.pdf" {
+		t.Errorf("candidates = %v, want [~/doc.pdf]", cands)
+	}
+	var got Request
+	if err := decodeRequestFrame(ch.Writes[0], &got); err != nil {
+		t.Fatalf("unmarshal request: %v", err)
+	}
+	if got.Path != "/home/alice" {
+		t.Errorf("request path = %q, want %q", got.Path, "/home/alice")
+	}
+}
+
+// TestCompleterGetTildeTarget verifies that a tilde target of get (the local
+// side) completes against the local home directory.
+func TestCompleterGetTildeTarget(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "local.txt"), nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	localDir, remoteDir := "/local", "/remote"
+	c := newCompleter(nil, &localDir, &remoteDir, "/home/alice", dir)
+
+	cands, _ := c([]rune("get remote.txt ~/l"), 17)
+	if len(cands) != 1 || cands[0] != "~/local.txt" {
+		t.Errorf("get tilde target candidates = %v, want [~/local.txt]", cands)
+	}
+}
+
+// TestCompletePathBareTilde verifies the completePath-level handling of a
+// bare tilde word: it lists the home directory and renders "~/"-prefixed
+// candidates, delegating the actual home resolution to the listDir closure.
+func TestCompletePathBareTilde(t *testing.T) {
+	listDir := func(dir string) ([]string, error) {
+		if dir == "~" {
+			return []string{"go/", "notes.txt"}, nil
+		}
+		t.Errorf("unexpected listDir(%q)", dir)
+		return nil, os.ErrNotExist
+	}
+	got := completePath("~", listDir)
+	want := []string{"~/go/", "~/notes.txt"}
+	if len(got) != len(want) {
+		t.Fatalf("completePath(~) = %v, want %v", got, want)
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Fatalf("completePath(~) = %v, want %v", got, want)
+		}
 	}
 }

--- a/sftp/quoting_test.go
+++ b/sftp/quoting_test.go
@@ -638,7 +638,7 @@ func TestCompleterQuotedWord(t *testing.T) {
 		FileInfo{Name: "remote.txt"},
 	)}))
 	localDir, remoteDir := "/local", "/remote"
-	c := newCompleter(ch, &localDir, &remoteDir)
+	c := newCompleter(ch, &localDir, &remoteDir, "/remote/home", "/local/home")
 
 	cands, start := c([]rune("get 'rem"), 8)
 	if start != 4 {
@@ -657,7 +657,7 @@ func TestCompleterQuotedWordWithSpace(t *testing.T) {
 		FileInfo{Name: "foobar.txt"},
 	)}))
 	localDir, remoteDir := "/local", "/remote"
-	c := newCompleter(ch, &localDir, &remoteDir)
+	c := newCompleter(ch, &localDir, &remoteDir, "/remote/home", "/local/home")
 
 	cands, start := c([]rune("cd 'my dir/fo"), 13)
 	if start != 3 {
@@ -686,7 +686,7 @@ func TestCompleterQuotedWordSpecialChars(t *testing.T) {
 		}
 	}
 	localDir, remoteDir := dir, "/remote"
-	c := newCompleter(nil, &localDir, &remoteDir)
+	c := newCompleter(nil, &localDir, &remoteDir, "/remote/home", "/local/home")
 
 	// Unquoted completion escapes the space, quote and star.
 	cands, start := c([]rune("lls "), 4)
@@ -753,7 +753,7 @@ func TestCompleterUTF8Spans(t *testing.T) {
 		FileInfo{Name: "café.txt"},
 	)}))
 	localDir, remoteDir := "/local", "/remote"
-	c := newCompleter(ch, &localDir, &remoteDir)
+	c := newCompleter(ch, &localDir, &remoteDir, "/remote/home", "/local/home")
 
 	// "cd docé/ca" — the first argument starts at rune index 3.
 	buf := []rune("cd docé/ca")

--- a/sftp/sftp_test.go
+++ b/sftp/sftp_test.go
@@ -2589,3 +2589,152 @@ func TestResolveCDTarget(t *testing.T) {
 		})
 	}
 }
+
+// --- Tilde expansion ---
+
+func TestExpandTilde(t *testing.T) {
+	const remoteHome = "/home/alice"
+	const localHome = "/home/bob"
+
+	// Remote paths are joined and cleaned with path.Join.
+	remoteCases := []struct {
+		in, want string
+	}{
+		{"~", remoteHome},
+		{"~/", remoteHome},
+		{"~/docs", remoteHome + "/docs"},
+		{"~/a/b", remoteHome + "/a/b"},
+		{"~/./x", remoteHome + "/x"},
+		{"~/../x", "/home/x"}, // cleaned like a shell path
+		{"~user", "~user"},    // ~other users are not expanded
+		{"foo~", "foo~"},      // tilde not at the start is literal
+		{"~/docs", remoteHome + "/docs"},
+		{"sub/dir", "sub/dir"},
+		{"", ""},
+	}
+	for _, c := range remoteCases {
+		if got := expandTildePath(c.in, remoteHome); got != c.want {
+			t.Errorf("expandTildePath(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+
+	// Local paths are joined and cleaned with filepath.Join.
+	localCases := []struct {
+		in, want string
+	}{
+		{"~", localHome},
+		{"~/", localHome},
+		{"~/docs", localHome + "/docs"},
+		{"~/a/b", localHome + "/a/b"},
+		{"~bob", "~bob"},
+		{"foo~", "foo~"},
+		{"", ""},
+	}
+	for _, c := range localCases {
+		if got := expandLocalTilde(c.in, localHome); got != c.want {
+			t.Errorf("expandLocalTilde(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+
+	// An unknown home leaves the path untouched, so the command fails with
+	// the underlying error instead of silently pointing at an empty path.
+	if got := expandTildePath("~/x", ""); got != "~/x" {
+		t.Errorf("expandTildePath with empty home = %q, want %q", got, "~/x")
+	}
+	if got := expandLocalTilde("~", ""); got != "~" {
+		t.Errorf("expandLocalTilde with empty home = %q, want %q", got, "~")
+	}
+}
+
+func TestExpandCommandArgs(t *testing.T) {
+	const remoteHome = "/home/alice"
+	const localHome = "/home/bob"
+
+	cases := []struct {
+		name  string
+		parts []string
+		want  []string
+	}{
+		// Remote-only commands expand to the remote home.
+		{name: "ls bare tilde", parts: []string{"ls", "~"}, want: []string{"ls", remoteHome}},
+		{name: "ls tilde subdir", parts: []string{"ls", "~/docs"}, want: []string{"ls", remoteHome + "/docs"}},
+		{name: "ls tilde glob", parts: []string{"ls", "~/te*"}, want: []string{"ls", remoteHome + "/te*"}},
+		{name: "mkdir", parts: []string{"mkdir", "~/new"}, want: []string{"mkdir", remoteHome + "/new"}},
+		{name: "rm", parts: []string{"rm", "~/f.txt"}, want: []string{"rm", remoteHome + "/f.txt"}},
+		{name: "rmdir", parts: []string{"rmdir", "~/d"}, want: []string{"rmdir", remoteHome + "/d"}},
+		// Relative paths and non-tilde arguments are left alone.
+		{name: "ls relative", parts: []string{"ls", "docs"}, want: []string{"ls", "docs"}},
+		{name: "ls absolute", parts: []string{"ls", "/etc"}, want: []string{"ls", "/etc"}},
+		// Local commands expand to the local home.
+		{name: "lcd", parts: []string{"lcd", "~"}, want: []string{"lcd", localHome}},
+		{name: "lls", parts: []string{"lls", "~/pics"}, want: []string{"lls", localHome + "/pics"}},
+		// get: source is remote, target is local.
+		{name: "get remote source", parts: []string{"get", "~"}, want: []string{"get", remoteHome}},
+		{name: "get local target", parts: []string{"get", "f", "~"}, want: []string{"get", "f", localHome}},
+		{name: "get both", parts: []string{"get", "~/f", "~"}, want: []string{"get", remoteHome + "/f", localHome}},
+		{name: "get -r flags", parts: []string{"get", "-r", "~/f", "~"}, want: []string{"get", "-r", remoteHome + "/f", localHome}},
+		// put: source is local, target is remote.
+		{name: "put local source", parts: []string{"put", "~"}, want: []string{"put", localHome}},
+		{name: "put remote target", parts: []string{"put", "f", "~"}, want: []string{"put", "f", remoteHome}},
+		{name: "put both", parts: []string{"put", "~/f", "~"}, want: []string{"put", localHome + "/f", remoteHome}},
+		{name: "put --recursive", parts: []string{"put", "--recursive", "~/f", "~/d"},
+			want: []string{"put", "--recursive", localHome + "/f", remoteHome + "/d"}},
+		// cd resolves "~" itself and is left untouched here.
+		{name: "cd untouched", parts: []string{"cd", "~"}, want: []string{"cd", "~"}},
+		// Commands without path arguments are untouched.
+		{name: "pwd", parts: []string{"pwd"}, want: []string{"pwd"}},
+		{name: "lpwd", parts: []string{"lpwd"}, want: []string{"lpwd"}},
+		{name: "help", parts: []string{"help"}, want: []string{"help"}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			parts := append([]string(nil), c.parts...)
+			expandCommandArgs(parts, remoteHome, localHome)
+			if len(parts) != len(c.want) {
+				t.Fatalf("expandCommandArgs(%v) = %v, want %v", c.parts, parts, c.want)
+			}
+			for i := range parts {
+				if parts[i] != c.want[i] {
+					t.Fatalf("expandCommandArgs(%v) = %v, want %v", c.parts, parts, c.want)
+				}
+			}
+		})
+	}
+}
+
+func TestTransferArgIndices(t *testing.T) {
+	if s, tg := transferArgIndices([]string{"get", "src"}); s != 1 || tg != 2 {
+		t.Errorf("no target: source=%d target=%d, want 1 and 2", s, tg)
+	}
+	if s, tg := transferArgIndices([]string{"get", "src", "dst"}); s != 1 || tg != 2 {
+		t.Errorf("with target: source=%d target=%d, want 1 and 2", s, tg)
+	}
+	if s, tg := transferArgIndices([]string{"get", "-r", "src", "dst"}); s != 2 || tg != 3 {
+		t.Errorf("with -r: source=%d target=%d, want 2 and 3", s, tg)
+	}
+	if s, tg := transferArgIndices([]string{"put", "--recursive", "src"}); s != 2 || tg != 3 {
+		t.Errorf("with --recursive: source=%d target=%d, want 2 and 3", s, tg)
+	}
+}
+
+// TestClientDoLsTildeExpandedAbsolute pins that an ls argument whose tilde
+// has been expanded at dispatch time (an absolute path) is sent to the server
+// as-is rather than being joined onto the remote working directory.
+func TestClientDoLsTildeExpandedAbsolute(t *testing.T) {
+	ch := newMockChannel(makeResponseMsg(&Response{OK: true, Entries: lsEntries("notes.txt")}))
+	// parts simulate the output of expandCommandArgs(["ls", "~"]) with a
+	// remote home of /home/alice.
+	if err := doLs(ch, "/remote", []string{"ls", "/home/alice"}); err != nil {
+		t.Fatalf("doLs error: %v", err)
+	}
+	var got Request
+	if len(ch.Writes) != 1 {
+		t.Fatalf("expected 1 request, got %d", len(ch.Writes))
+	}
+	if err := decodeRequestFrame(ch.Writes[0], &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.Cmd != "ls" || got.Path != "/home/alice" {
+		t.Fatalf("expected ls /home/alice, got %s %q", got.Cmd, got.Path)
+	}
+}


### PR DESCRIPTION
Handle a leading ~ or ~/ in every SFTP command argument: expand it to the remote user's home for remote arguments (ls, mkdir, rm, rmdir, the get source and put target) and to the local client user's home for local arguments (lcd, lls, the get target and put source), mirroring shell semantics. Add the same expansion to tab completion, and resolve absolute paths in lls via resolveLocalPath. Update help and README.

Add unit tests for expansion, transfer-argument indexing, and remote, local and tilde-based completion.