### PR TITLE
sftp: continue put -r past permission-denied files

### DIFF
--- a/sftp/client.go
+++ b/sftp/client.go
@@ -765,6 +765,12 @@ func doPut(channel ssh3.Channel, localDir, remoteDir string, parts []string, fol
 		}
 
 		if err := uploadOne(channel, localFile, remoteFile, recursive, follow, cancel); err != nil {
+			// With -r a permission-denied match is reported and skipped so
+			// the remaining matches are still transferred.
+			if recursive && isPermissionError(err) {
+				fmt.Fprintf(os.Stderr, "put: %s\n", err)
+				continue
+			}
 			return err
 		}
 	}
@@ -1090,6 +1096,12 @@ func uploadRecursive(channel ssh3.Channel, localPath, remotePath string, follow 
 		childRemote := path.Join(remotePath, entry.Name())
 		childInfo, err := statLocal(childLocal, follow)
 		if err != nil {
+			// A permission-denied entry is reported and skipped so the rest
+			// of the directory is still transferred.
+			if isPermissionError(err) {
+				fmt.Fprintf(os.Stderr, "put: %s\n", err)
+				continue
+			}
 			return err
 		}
 		if !follow && childInfo.Mode()&os.ModeSymlink != 0 {
@@ -1097,9 +1109,22 @@ func uploadRecursive(channel ssh3.Channel, localPath, remotePath string, follow 
 		}
 		if childInfo.IsDir() {
 			if err := uploadRecursive(channel, childLocal, childRemote, follow, cancel); err != nil {
+				// A permission-denied subtree (e.g. an unreadable directory or
+				// one the server refuses to create) is reported and skipped
+				// so the rest of the directory is still transferred.
+				if isPermissionError(err) {
+					fmt.Fprintf(os.Stderr, "put: %s\n", err)
+					continue
+				}
 				return err
 			}
 		} else if err := uploadFile(channel, childLocal, childRemote, follow, cancel); err != nil {
+			// A permission-denied file is reported and skipped so the rest
+			// of the directory is still transferred.
+			if isPermissionError(err) {
+				fmt.Fprintf(os.Stderr, "put: %s\n", err)
+				continue
+			}
 			return err
 		}
 	}
@@ -1275,8 +1300,9 @@ func serverError(path, msg string) error {
 
 // isPermissionError reports whether err is a permission failure: the read or
 // listing of a file the user may not access, reported by the server, or a
-// local permission error while creating the destination. The recursive
-// download skips such entries and continues with the rest of the directory.
+// local permission error while reading the source or creating the
+// destination. Recursive transfers skip such entries and continue with the
+// rest of the directory.
 func isPermissionError(err error) bool {
 	if err == nil {
 		return false
@@ -1423,19 +1449,35 @@ func uploadFile(channel ssh3.Channel, localPath, remotePath string, follow bool,
 		return chunkBuf[:n], off, nil
 	}
 
-	// Issue the initial window of write requests.
+	// drain consumes the responses still in flight for this transfer; it is
+	// called on every error path below. The server answers strictly in request
+	// order, so every response drained belongs to a request sent for
+	// remotePath: without the drain the next transfer would mistake them for
+	// its own responses (a denied file would wrongly deny the file after it).
 	nextChunk := 0
 	pending := 0
+	drain := func() {
+		for pending > 0 {
+			pending--
+			if _, err := ReceiveResponse(channel); err != nil {
+				break
+			}
+		}
+	}
+
+	// Issue the initial window of write requests.
 	for pending < window && nextChunk < chunks {
 		if prog.cancelled() {
 			return ErrCancelled
 		}
 		data, off, err := readChunk()
 		if err != nil {
+			drain()
 			return err
 		}
 		if len(data) > 0 {
 			if err := SendRequest(channel, &Request{Cmd: "put", Path: remotePath, Offset: off, Data: data}); err != nil {
+				drain()
 				return err
 			}
 		}
@@ -1456,8 +1498,14 @@ func uploadFile(channel ssh3.Channel, localPath, remotePath string, follow bool,
 		if err != nil {
 			return err
 		}
+		pending--
 		if !resp.OK {
-			return serverError(remotePath, resp.Error)
+			// The server denied this write (e.g. permission denied). Every
+			// request in the window is denied too: drain them so the rest of
+			// the directory is still transferred cleanly.
+			err := serverError(remotePath, resp.Error)
+			drain()
+			return err
 		}
 		n := int64(ChunkSize)
 		if remaining := total - int64(acked)*ChunkSize; remaining < n {
@@ -1467,14 +1515,15 @@ func uploadFile(channel ssh3.Channel, localPath, remotePath string, follow bool,
 			prog.add(n)
 		}
 		acked++
-		pending--
 		if nextChunk < chunks {
 			data, off, err := readChunk()
 			if err != nil {
+				drain()
 				return err
 			}
 			if len(data) > 0 {
 				if err := SendRequest(channel, &Request{Cmd: "put", Path: remotePath, Offset: off, Data: data}); err != nil {
+					drain()
 					return err
 				}
 			}

--- a/sftp/sftp_test.go
+++ b/sftp/sftp_test.go
@@ -2174,6 +2174,141 @@ func TestClientDoPutWildcardToNonDirectory(t *testing.T) {
 	}
 }
 
+// TestClientDoPutRecursivePermissionDenied exercises put -r on a directory
+// containing a mix of uploadable files and files the server refuses to write
+// (permission denied): each denied file is reported and skipped, and every
+// uploadable file is still uploaded. sa.bin is larger than one chunk so its
+// write window has several in-flight requests, all of which the server
+// denies: the client must drain them so they are not mistaken for the next
+// file's responses. sc.txt sorts after the denied files, so it proves the
+// drained responses of sa.bin were not mistaken for its own.
+func TestClientDoPutRecursivePermissionDenied(t *testing.T) {
+	localDir := t.TempDir()
+	root := filepath.Join(localDir, "d")
+	os.MkdirAll(root, 0o755)
+
+	// A large denied file spans three chunks: three write requests go out and
+	// the server denies all three.
+	bigSize := int64(2*ChunkSize + 10)
+	os.WriteFile(filepath.Join(root, "ok1.txt"), []byte("O1"), 0644)
+	os.WriteFile(filepath.Join(root, "ok2.txt"), []byte("OK2"), 0644)
+	os.WriteFile(filepath.Join(root, "ok3.txt"), []byte("OK3"), 0644)
+	os.WriteFile(filepath.Join(root, "sa.bin"), bytes.Repeat([]byte("s"), int(bigSize)), 0644)
+	os.WriteFile(filepath.Join(root, "sb.txt"), []byte("x"), 0644)
+	os.WriteFile(filepath.Join(root, "sc.txt"), []byte("SC"), 0644)
+
+	ch := newMockChannel(
+		// stat of the top-level directory.
+		makeResponseMsg(&Response{OK: true, Info: &FileInfo{Name: "d", IsDir: true}}),
+		// The uploads of ok1.txt, ok2.txt and ok3.txt succeed.
+		makeResponseMsg(&Response{OK: true}),
+		makeResponseMsg(&Response{OK: true}),
+		makeResponseMsg(&Response{OK: true}),
+		// The server denies all three writes of sa.bin.
+		makeResponseMsg(&Response{OK: false, Error: "sa.bin: permission denied"}),
+		makeResponseMsg(&Response{OK: false, Error: "sa.bin: permission denied"}),
+		makeResponseMsg(&Response{OK: false, Error: "sa.bin: permission denied"}),
+		// The server refuses the single write of sb.txt.
+		makeResponseMsg(&Response{OK: false, Error: "sb.txt: permission denied"}),
+		// The upload of sc.txt succeeds, proving the drained responses of
+		// sa.bin were not mistaken for its own.
+		makeResponseMsg(&Response{OK: true}),
+	)
+
+	if err := doPut(ch, localDir, "/remote", []string{"put", "-r", "d"}, true, nil); err != nil {
+		t.Fatalf("doPut -r error: %v", err)
+	}
+
+	// Every pre-programmed response must have been consumed: the denied
+	// file's in-flight responses were drained rather than left to be
+	// mistaken for the next file's, and every uploadable file was
+	// transferred.
+	if ch.MsgIndex != len(ch.NextMsgs) {
+		t.Fatalf("expected all %d responses to be consumed, got %d: the denied file's in-flight responses were not drained", len(ch.NextMsgs), ch.MsgIndex)
+	}
+
+	// The uploadable files must have been written to the server; the denied
+	// ones are reported and skipped but their requests are still sent.
+	var got Request
+	var paths []string
+	for _, w := range ch.Writes {
+		if err := decodeRequestFrame(w, &got); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if got.Cmd == "put" {
+			paths = append(paths, got.Path)
+		}
+	}
+	for _, want := range []string{
+		"/remote/d/ok1.txt",
+		"/remote/d/ok2.txt",
+		"/remote/d/ok3.txt",
+		"/remote/d/sc.txt",
+	} {
+		found := false
+		for _, p := range paths {
+			if p == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected put of %s, got puts %v", want, paths)
+		}
+	}
+}
+
+// TestClientDoPutRecursivePermissionDeniedWildcard exercises put -r with a
+// glob source where one match is denied by the server: the denied match is
+// reported and skipped and the remaining matches are still uploaded,
+// mirroring the permission handling of a recursive get.
+func TestClientDoPutRecursivePermissionDeniedWildcard(t *testing.T) {
+	localDir := t.TempDir()
+	os.WriteFile(filepath.Join(localDir, "a.txt"), []byte("A"), 0644)
+	os.WriteFile(filepath.Join(localDir, "b.txt"), []byte("B"), 0644)
+	os.WriteFile(filepath.Join(localDir, "c.txt"), []byte("C"), 0644)
+
+	ch := newMockChannel(
+		// The upload of a.txt succeeds.
+		makeResponseMsg(&Response{OK: true}),
+		// The server refuses to write b.txt.
+		makeResponseMsg(&Response{OK: false, Error: "b.txt: permission denied"}),
+		// The upload of c.txt succeeds.
+		makeResponseMsg(&Response{OK: true}),
+	)
+
+	if err := doPut(ch, localDir, "/remote", []string{"put", "-r", "*.txt"}, true, nil); err != nil {
+		t.Fatalf("doPut -r wildcard error: %v", err)
+	}
+
+	if ch.MsgIndex != len(ch.NextMsgs) {
+		t.Fatalf("expected all %d responses to be consumed, got %d", len(ch.NextMsgs), ch.MsgIndex)
+	}
+
+	var got Request
+	var paths []string
+	for _, w := range ch.Writes {
+		if err := decodeRequestFrame(w, &got); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if got.Cmd == "put" {
+			paths = append(paths, got.Path)
+		}
+	}
+	for _, want := range []string{"/remote/a.txt", "/remote/c.txt"} {
+		found := false
+		for _, p := range paths {
+			if p == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected put of %s, got puts %v", want, paths)
+		}
+	}
+}
+
 // TestClientDoPutSingleToRemoteDir verifies that a single-source put to an
 // existing remote directory copies the file into it under its own basename.
 func TestClientDoPutSingleToRemoteDir(t *testing.T) {


### PR DESCRIPTION
put -r aborted the whole recursive transfer on the first permission error and, when the server denied a multi-chunk file, left its in-flight responses queued where the next file would mistake them for its own. Mirror the get -r handling (commits a3a01d0, 734b3f1):

- doPut and uploadRecursive report and skip permission-denied sources, subtrees and files, transferring the rest of the directory.
- uploadFile drains in-flight responses on every error path so a denied file's responses are not misattributed to the file after it.

Verified with two unit tests and a live end-to-end test against the real server.