### PR TITLE
sshoq: add -config-dir flag for custom client config directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,12 @@ You can connect to your SSHOQ server at my-server.example.org listening on `/my-
 
       sshoq -i ~/.ssh/id_rsa username@my-server.example.org/my-secret-path
 
+### Custom config directory
+
+By default the SSHOQ client stores its configuration data (such as the `known_hosts` file and the OIDC issuer config) in `~/.ssh3`. You can override this directory with the `-config-dir` flag:
+
+`sshoq -config-dir /path/to/my/config username@my-server.example.org/my-secret-path`
+
 ### Alternate port
 
 Put the alternative port in the URL like so:

--- a/cmd/sshoq.go
+++ b/cmd/sshoq.go
@@ -46,6 +46,16 @@ func homedir() string {
 	}
 }
 
+// resolveConfigDir returns the directory used to store client configuration
+// data (known_hosts, oidc_config.json, ...). When configDir is non-empty it
+// is used as-is, otherwise the default ~/.ssh3 directory is used.
+func resolveConfigDir(configDir string) string {
+	if configDir != "" {
+		return configDir
+	}
+	return path.Join(homedir(), ".ssh3")
+}
+
 // Prepares the QUIC connection that will be used by SSH3
 // If non-nil, use udpConn as transport (can be used for proxy jump)
 // Otherwise, create a UDPConn from udp://host:port
@@ -613,6 +623,7 @@ func ClientMain() int {
 	issuerUrl := flag.String("use-oidc", "", "if set, force the use of OpenID Connect with the specified issuer url as parameter (it opens a browser window)")
 	oidcConfigFileName := flag.String("oidc-config", "", "OpenID Connect json config file containing the \"client_id\" and \"client_secret\" fields needed for most identity providers")
 	verbose := flag.Bool("v", false, "if set, enable verbose mode")
+	configDir := flag.String("config-dir", "", "if set, use the specified directory for client configuration data (known_hosts, oidc_config.json, ...) instead of the default ~/.ssh3")
 	displayVersion := flag.Bool("version", false, "if set, displays the software version on standard output and exit")
 	noPKCE := flag.Bool("no-pkce", false, "if set perform PKCE challenge-response with oidc")
 	forcePTYAlloc := flag.Bool("force-pty", false, "if set, forces PTY allocation before command execution. Useful for interactive programs.")
@@ -674,7 +685,7 @@ func ClientMain() int {
 
 	useOIDC := *issuerUrl != ""
 
-	ssh3Dir := path.Join(homedir(), ".ssh3")
+	ssh3Dir := resolveConfigDir(*configDir)
 	os.MkdirAll(ssh3Dir, 0700)
 
 	if len(args) == 0 {

--- a/cmd/sshoq_test.go
+++ b/cmd/sshoq_test.go
@@ -21,6 +21,44 @@ func testOptionParsers() map[config.OptionName]config.OptionParser {
 	}
 }
 
+// --- config-dir resolution tests ---
+
+// When -config-dir is empty, the default ~/.ssh3 directory must be used.
+func TestResolveConfigDirDefault(t *testing.T) {
+	// homedir() prefers os/user.Current().HomeDir and ignores the HOME env
+	// var when the current user can be resolved, so compute the expected value
+	// from homedir() itself.
+	expected := path.Join(homedir(), ".ssh3")
+	got := resolveConfigDir("")
+	if got != expected {
+		t.Errorf("expected %s, got %s", expected, got)
+	}
+}
+
+// When -config-dir is provided, it must be used as-is instead of the default.
+func TestResolveConfigDirCustom(t *testing.T) {
+	custom := path.Join(t.TempDir(), "my-custom-config")
+	got := resolveConfigDir(custom)
+	if got != custom {
+		t.Errorf("expected %s, got %s", custom, got)
+	}
+}
+
+// The custom config dir must be used even when HOME points elsewhere.
+func TestResolveConfigDirCustomOverridesHome(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+
+	custom := path.Join(t.TempDir(), "other")
+	got := resolveConfigDir(custom)
+	if got != custom {
+		t.Errorf("expected %s, got %s", custom, got)
+	}
+	if got == path.Join(tmpDir, ".ssh3") {
+		t.Errorf("custom config dir should not fall back to ~/.ssh3")
+	}
+}
+
 // When no identity is configured anywhere, the default private keys from
 // ~/.ssh must be used.
 func TestGetConnectionMaterialFromURL_DefaultKeysFromDotSSH(t *testing.T) {


### PR DESCRIPTION
Add a -config-dir flag to the sshoq client so users can override the default ~/.ssh3 directory used for client configuration data (known_hosts, oidc_config.json, ...). Extract the directory resolution into a resolveConfigDir helper and cover it with tests.